### PR TITLE
[FEAT] 경로 그리기 기능 및 장소 draggable 적용  + polyline 중복 관련 트러블슈팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "vaul-vue": "^0.4.1",
         "vue": "^3.5.13",
         "vue-router": "^4.5.1",
-        "vue-sonner": "^2.0.0"
+        "vue-sonner": "^2.0.0",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@types/google.maps": "^3.58.1",
@@ -5288,6 +5289,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6098,6 +6105,18 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/webpack-virtual-modules": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "vaul-vue": "^0.4.1",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1",
-    "vue-sonner": "^2.0.0"
+    "vue-sonner": "^2.0.0",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@types/google.maps": "^3.58.1",

--- a/src/components/plan/Step3AccommodationSetting.vue
+++ b/src/components/plan/Step3AccommodationSetting.vue
@@ -115,46 +115,47 @@ function getDateForDay(day: number): string {
     weekday: 'short',
   });
 }
+const accommodationIconMap: Record<string, string> = {
+  hotel: '🏨',
+  lodging: '🏨',
+  motel: '🏩',
+  resort: '🏖️',
+  campground: '🏕️',
+  rv_park: '🏕️',
+  spa: '♨️',
+  guest_house: '🏠',
+  hostel: '🛏️',
+  apartment: '🏢',
+  real_estate_agency: '🏢',
+};
+
+const nameKeywordMap: Record<string, string> = {
+  펜션: '🏡',
+  리조트: '🏖️',
+  모텔: '🏩',
+  게스트하우스: '🏠',
+  민박: '🏠',
+  호스텔: '🛏️',
+  캠핑: '🏕️',
+  글램핑: '🏕️',
+  스파: '♨️',
+  온천: '♨️',
+};
 
 function getAccommodationIcon(place: PlaceResult): string {
   if (!place.types) return '🏨';
 
-  // 숙소 유형별 아이콘 매핑
+  // 타입 기반 매핑
   for (const type of place.types) {
-    switch (type.toLowerCase()) {
-      case 'hotel':
-      case 'lodging':
-        return '🏨'; // 호텔
-      case 'motel':
-        return '🏩'; // 모텔
-      case 'resort':
-        return '🏖️'; // 리조트
-      case 'campground':
-      case 'rv_park':
-        return '🏕️'; // 캠핑장
-      case 'spa':
-        return '♨️'; // 스파
-      case 'guest_house':
-        return '🏠'; // 게스트하우스
-      case 'hostel':
-        return '🛏️'; // 호스텔
-      case 'apartment':
-      case 'real_estate_agency':
-        return '🏢'; // 아파트/숙박업소
-      default:
-        continue;
-    }
+    const icon = accommodationIconMap[type.toLowerCase()];
+    if (icon) return icon;
   }
 
-  // 숙소 이름으로 추가 판단
+  // 이름 기반 매핑
   const name = place.name.toLowerCase();
-  if (name.includes('펜션')) return '🏡';
-  if (name.includes('리조트')) return '🏖️';
-  if (name.includes('모텔')) return '🏩';
-  if (name.includes('게스트하우스') || name.includes('민박')) return '🏠';
-  if (name.includes('호스텔')) return '🛏️';
-  if (name.includes('캠핑') || name.includes('글램핑')) return '🏕️';
-  if (name.includes('스파') || name.includes('온천')) return '♨️';
+  for (const [keyword, icon] of Object.entries(nameKeywordMap)) {
+    if (name.includes(keyword)) return icon;
+  }
 
   return '🏨';
 }

--- a/src/components/plan/Step3AccommodationSetting.vue
+++ b/src/components/plan/Step3AccommodationSetting.vue
@@ -6,50 +6,75 @@
     <!-- 선택한 숙소 목록 -->
     <div class="mt-6">
       <h3 class="mb-3 text-lg font-semibold">선택한 숙소</h3>
-      <ScrollArea>
-        <div v-for="day in Object.keys(dayPlans).map(Number)" :key="day" class="mb-4">
-          <div class="mb-2 text-sm font-medium">{{ day }}일차</div>
-
-          <!-- 숙소 표시 -->
-          <div v-if="dayPlans[day].accommodation" class="mb-2">
-            <div
-              class="border-secondary bg-secondary/10 flex items-center justify-between rounded-md border p-2 text-sm"
-            >
+      <ScrollArea class="h-[calc(100vh-200px)]">
+        <div v-for="day in Object.keys(dayPlans).map(Number)" :key="day" class="mb-6">
+          <div class="mb-3 flex items-center justify-between">
+            <div class="flex items-center gap-3">
               <div
-                class="flex-1 cursor-pointer"
-                @click="handleAccommodationClick(dayPlans[day].accommodation)"
+                class="flex h-10 w-20 items-center justify-center rounded-lg text-lg font-bold text-white shadow-md"
+                :style="{ backgroundColor: getDayColor(day) }"
               >
-                <div class="font-bold text-gray-800">🏨 {{ dayPlans[day].accommodation.name }}</div>
-                <div class="text-xs font-bold text-gray-800">
-                  {{ dayPlans[day].accommodation.address }}
-                </div>
-                <div
-                  v-if="dayPlans[day].accommodation!.rating"
-                  class="flex items-center gap-1 text-xs text-yellow-600"
-                >
-                  <span>⭐</span>
-                  <span>{{ dayPlans[day].accommodation!.rating.toFixed(1) }}</span>
-                  <span v-if="dayPlans[day].accommodation!.userRatingsTotal" class="text-gray-400">
-                    ({{ dayPlans[day].accommodation!.userRatingsTotal }}개 리뷰)
-                  </span>
-                </div>
+                Day {{ day }}
               </div>
-              <button
-                class="hover:bg-secondary/20 ml-2 rounded-full p-1"
-                @click="removeAccommodation(day, dayPlans[day].accommodation!.placeId)"
-              >
-                <XIcon class="text-secondary h-4 w-4 hover:text-red-500" />
-              </button>
+              <div class="text-sm text-gray-500">
+                {{ getDateForDay(day) }}
+              </div>
+            </div>
+            <div class="text-xs text-gray-400">
+              {{ dayPlans[day].accommodation ? '숙소 선택됨' : '숙소 없음' }}
             </div>
           </div>
 
-          <!-- 빈 상태 표시 -->
-          <div v-if="!dayPlans[day].accommodation" class="py-4 text-center text-xs text-gray-400">
-            선택된 숙소가 없습니다
+          <!-- 숙소 표시 -->
+          <div class="rounded-lg border border-gray-200 bg-white">
+            <div v-if="dayPlans[day].accommodation" class="p-4">
+              <div
+                class="group -m-2 flex items-center gap-3 rounded-lg p-2 transition-all duration-200 hover:bg-gray-50"
+              >
+                <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100">
+                  <span class="text-xl">
+                    {{ getAccommodationIcon(dayPlans[day].accommodation) }}
+                  </span>
+                </div>
+                <div
+                  class="flex-1 cursor-pointer"
+                  @click="handleAccommodationClick(dayPlans[day].accommodation)"
+                >
+                  <div class="font-semibold text-gray-800">
+                    {{ dayPlans[day].accommodation.name }}
+                  </div>
+                  <div class="text-sm text-gray-500">
+                    {{ dayPlans[day].accommodation.address }}
+                  </div>
+                </div>
+                <button
+                  class="rounded-full p-2 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-50"
+                  @click="removeAccommodation(day, dayPlans[day].accommodation!.placeId)"
+                >
+                  <XIcon class="h-4 w-4 text-gray-400 hover:text-red-500" />
+                </button>
+              </div>
+            </div>
+
+            <!-- 빈 상태 표시 -->
+            <div
+              v-if="!dayPlans[day].accommodation"
+              class="flex flex-col items-center justify-center py-4 text-gray-400"
+            >
+              <span class="mb-2 text-2xl">🏨</span>
+              <div class="text-sm">선택된 숙소가 없습니다</div>
+              <div class="text-xs">우측에서 숙소를 검색해서 추가해보세요</div>
+            </div>
           </div>
         </div>
-        <div v-if="!Object.keys(dayPlans).length" class="py-8 text-center text-gray-400">
-          아직 선택된 숙소가 없습니다
+
+        <div
+          v-if="!Object.keys(dayPlans).length"
+          class="flex flex-col items-center py-12 text-gray-400"
+        >
+          <Calendar class="mb-3 h-12 w-12" />
+          <div class="text-lg font-medium">여행 일정을 설정해주세요</div>
+          <div class="text-sm">Step 1에서 날짜를 먼저 선택해주세요</div>
         </div>
       </ScrollArea>
     </div>
@@ -58,23 +83,82 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { XIcon } from 'lucide-vue-next';
+import { XIcon, Calendar } from 'lucide-vue-next';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { usePlanStore } from '@/stores/plan';
+import { dayColors } from '@/composables/plan/usePlanMap';
 import type { PlaceResult } from '@/composables/plan/usePlaceSearch';
 
 const planStore = usePlanStore();
 
-// Computed
 const dayPlans = computed(() => planStore.dayPlans);
 
-// Emits
 const emit = defineEmits<{
   accommodationClick: [place: PlaceResult];
   removeAccommodation: [day: number, placeId: string];
 }>();
 
-// Methods
+function getDayColor(day: number): string {
+  return dayColors[day - 1] ?? '#888';
+}
+
+function getDateForDay(day: number): string {
+  if (!planStore.selectedDateRange.start) return '';
+
+  const startDate = new Date(planStore.selectedDateRange.start);
+  const targetDate = new Date(startDate);
+  targetDate.setDate(startDate.getDate() + day - 1);
+
+  return targetDate.toLocaleDateString('ko-KR', {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+function getAccommodationIcon(place: PlaceResult): string {
+  if (!place.types) return '🏨';
+
+  // 숙소 유형별 아이콘 매핑
+  for (const type of place.types) {
+    switch (type.toLowerCase()) {
+      case 'hotel':
+      case 'lodging':
+        return '🏨'; // 호텔
+      case 'motel':
+        return '🏩'; // 모텔
+      case 'resort':
+        return '🏖️'; // 리조트
+      case 'campground':
+      case 'rv_park':
+        return '🏕️'; // 캠핑장
+      case 'spa':
+        return '♨️'; // 스파
+      case 'guest_house':
+        return '🏠'; // 게스트하우스
+      case 'hostel':
+        return '🛏️'; // 호스텔
+      case 'apartment':
+      case 'real_estate_agency':
+        return '🏢'; // 아파트/숙박업소
+      default:
+        continue;
+    }
+  }
+
+  // 숙소 이름으로 추가 판단
+  const name = place.name.toLowerCase();
+  if (name.includes('펜션')) return '🏡';
+  if (name.includes('리조트')) return '🏖️';
+  if (name.includes('모텔')) return '🏩';
+  if (name.includes('게스트하우스') || name.includes('민박')) return '🏠';
+  if (name.includes('호스텔')) return '🛏️';
+  if (name.includes('캠핑') || name.includes('글램핑')) return '🏕️';
+  if (name.includes('스파') || name.includes('온천')) return '♨️';
+
+  return '🏨';
+}
+
 function handleAccommodationClick(place: PlaceResult) {
   emit('accommodationClick', place);
 }

--- a/src/components/plan/Step4PlaceSearch.vue
+++ b/src/components/plan/Step4PlaceSearch.vue
@@ -65,7 +65,7 @@
             chosen-class="chosen-card"
             drag-class="drag-card"
             @start="onDragStart"
-            @end="onDragEnd"
+            @end="evt => onDragEnd(evt, day)"
             class="min-h-[60px]"
           >
             <template #item="{ element: place, index }">
@@ -145,6 +145,7 @@ const dayPlans = computed(() => planStore.dayPlans);
 const emit = defineEmits<{
   placeClick: [place: PlaceResult];
   removePlace: [day: number, placeId: string];
+  orderChanged: [day: number]; // 순서 변경 이벤트 추가
 }>();
 
 function getDayColor(day: number): string {
@@ -186,8 +187,20 @@ function onDragStart() {
   isDragging.value = true;
 }
 
-function onDragEnd() {
+interface DragEvent {
+  oldIndex: number;
+  newIndex: number;
+}
+
+function onDragEnd(evt: DragEvent, day: number) {
   isDragging.value = false;
+
+  // 순서가 실제로 변경되었는지 확인
+  if (evt.oldIndex !== evt.newIndex) {
+    console.log(`Day ${day}: 드래그로 순서 변경됨 (${evt.oldIndex} -> ${evt.newIndex})`);
+    // 부모 컴포넌트에 순서 변경 알림
+    emit('orderChanged', day);
+  }
 }
 
 function getAccommodationIcon(place: PlaceResult): string {

--- a/src/components/plan/Step4PlaceSearch.vue
+++ b/src/components/plan/Step4PlaceSearch.vue
@@ -6,77 +6,262 @@
     <!-- 선택한 장소 목록 -->
     <div class="mt-6">
       <h3 class="mb-3 text-lg font-semibold">선택한 장소</h3>
-      <ScrollArea>
-        <div v-for="day in Object.keys(dayPlans).map(Number)" :key="day" class="mb-4">
-          <div class="mb-2 text-sm font-medium">{{ day }}일차</div>
-
-          <!-- 일반 장소들 표시 -->
-          <ul v-if="dayPlans[day].places.length > 0" class="space-y-2">
-            <li
-              v-for="(place, index) in dayPlans[day].places"
-              :key="place.placeId"
-              class="flex items-center justify-between rounded-md border p-2 text-sm"
+      <div v-for="day in Object.keys(dayPlans).map(Number)" :key="day" class="mb-6">
+        <div class="mb-3 flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div
+              class="flex h-10 w-20 items-center justify-center rounded-lg text-lg font-bold text-white shadow-md"
+              :style="{ backgroundColor: getDayColor(day) }"
             >
-              <div @click="handlePlaceClick(place)" class="flex-1 cursor-pointer">
-                <div class="font-medium">{{ index + 1 }}. {{ place.name }}</div>
-                <div class="text-xs text-gray-500">{{ place.address }}</div>
-                <div v-if="place.rating" class="flex items-center gap-1 text-xs text-yellow-600">
-                  <span>⭐</span>
-                  <span>{{ place.rating.toFixed(1) }}</span>
-                  <span v-if="place.userRatingsTotal" class="text-gray-400">
-                    ({{ place.userRatingsTotal }}개 리뷰)
-                  </span>
+              Day {{ day }}
+            </div>
+            <div class="text-sm text-gray-500">
+              {{ getDateForDay(day) }}
+            </div>
+          </div>
+          <div class="text-xs text-gray-400">{{ dayPlans[day].places.length }}개 장소</div>
+        </div>
+
+        <!-- 숙소 표시 -->
+        <div v-if="dayPlans[day].accommodation" class="mb-3">
+          <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <div
+              class="group -m-2 flex items-center gap-3 rounded-lg p-2 transition-all duration-200 hover:bg-gray-50"
+            >
+              <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100">
+                <span class="text-xl">
+                  {{ getAccommodationIcon(dayPlans[day].accommodation) }}
+                </span>
+              </div>
+              <div
+                class="flex-1 cursor-pointer"
+                @click="handleAccommodationClick(dayPlans[day].accommodation)"
+              >
+                <div class="font-semibold text-gray-800">
+                  {{ dayPlans[day].accommodation.name }}
+                </div>
+                <div class="text-sm text-gray-500">
+                  {{ dayPlans[day].accommodation.address }}
                 </div>
               </div>
               <button
-                @click="removePlace(day, place.placeId)"
-                class="ml-2 rounded-full p-1 hover:bg-gray-100"
+                class="rounded-full p-2 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-50"
+                @click="removeAccommodation(day, dayPlans[day].accommodation!.placeId)"
               >
                 <XIcon class="h-4 w-4 text-gray-400 hover:text-red-500" />
               </button>
-            </li>
-          </ul>
-
-          <!-- 빈 상태 표시 -->
-          <div
-            v-if="dayPlans[day].places.length === 0"
-            class="py-4 text-center text-xs text-gray-400"
-          >
-            선택된 장소가 없습니다
+            </div>
           </div>
         </div>
-        <div v-if="!Object.keys(dayPlans).length" class="py-8 text-center text-gray-400">
-          아직 선택된 장소가 없습니다
+
+        <!-- 드래그 가능한 장소 목록 -->
+        <div class="rounded-lg border border-gray-200 bg-white">
+          <draggable
+            v-model="dayPlans[day].places"
+            group="places"
+            item-key="placeId"
+            :animation="200"
+            ghost-class="ghost-card"
+            chosen-class="chosen-card"
+            drag-class="drag-card"
+            @start="onDragStart"
+            @end="onDragEnd"
+            class="min-h-[60px]"
+          >
+            <template #item="{ element: place, index }">
+              <div
+                class="group relative flex items-center gap-2 border-b border-gray-100 p-3 transition-all duration-200 last:border-b-0 hover:bg-gray-50"
+                :class="{ 'cursor-move': !isDragging }"
+              >
+                <!-- 드래그 핸들과 순서 번호 -->
+                <div class="flex items-center gap-1">
+                  <div class="cursor-move opacity-0 transition-opacity group-hover:opacity-100">
+                    <GripVertical class="h-4 w-4 text-gray-400" />
+                  </div>
+                  <div
+                    class="flex h-6 w-6 items-center justify-center rounded border-2 border-gray-300 bg-white text-xs font-bold text-gray-600"
+                  >
+                    {{ index + 1 }}
+                  </div>
+                </div>
+
+                <!-- 장소 정보 -->
+                <div @click="handlePlaceClick(place)" class="flex-1 cursor-pointer pl-2">
+                  <div class="font-semibold text-gray-800">{{ place.name }}</div>
+                  <div class="text-sm text-gray-500">{{ place.address }}</div>
+                </div>
+
+                <!-- 삭제 버튼 -->
+                <button
+                  class="rounded-full p-2 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-50"
+                  @click="removePlace(day, place.placeId)"
+                >
+                  <XIcon class="h-4 w-4 text-gray-400 hover:text-red-500" />
+                </button>
+              </div>
+            </template>
+
+            <!-- 빈 상태 표시 -->
+            <template #footer>
+              <div
+                v-if="dayPlans[day].places.length === 0"
+                class="flex flex-col items-center justify-center py-4 text-gray-400"
+              >
+                <MapPin class="mb-2 h-8 w-8" />
+                <div class="text-sm">선택된 장소가 없습니다</div>
+                <div class="text-xs">우측에서 장소를 검색해서 추가해보세요</div>
+              </div>
+            </template>
+          </draggable>
         </div>
-      </ScrollArea>
+      </div>
+
+      <div
+        v-if="!Object.keys(dayPlans).length"
+        class="flex flex-col items-center py-12 text-gray-400"
+      >
+        <Calendar class="mb-3 h-12 w-12" />
+        <div class="text-lg font-medium">여행 일정을 설정해주세요</div>
+        <div class="text-sm">Step 1에서 날짜를 먼저 선택해주세요</div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { XIcon } from 'lucide-vue-next';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { computed, ref } from 'vue';
+import { XIcon, GripVertical, MapPin, Calendar } from 'lucide-vue-next';
 import { usePlanStore } from '@/stores/plan';
+import { dayColors } from '@/composables/plan/usePlanMap';
 import type { PlaceResult } from '@/composables/plan/usePlaceSearch';
+import draggable from 'vuedraggable';
 
 const planStore = usePlanStore();
 
-// Computed
+const isDragging = ref(false);
+
 const dayPlans = computed(() => planStore.dayPlans);
 
-// Emits
 const emit = defineEmits<{
   placeClick: [place: PlaceResult];
   removePlace: [day: number, placeId: string];
 }>();
 
-// Methods
+function getDayColor(day: number): string {
+  return dayColors[day - 1] ?? '#888';
+}
+
+function getDateForDay(day: number): string {
+  if (!planStore.selectedDateRange.start) return '';
+
+  const startDate = new Date(planStore.selectedDateRange.start);
+  const targetDate = new Date(startDate);
+  targetDate.setDate(startDate.getDate() + day - 1);
+
+  return targetDate.toLocaleDateString('ko-KR', {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
 function handlePlaceClick(place: PlaceResult) {
+  emit('placeClick', place);
+}
+
+function handleAccommodationClick(place: PlaceResult) {
   emit('placeClick', place);
 }
 
 function removePlace(day: number, placeId: string) {
   emit('removePlace', day, placeId);
 }
+
+function removeAccommodation(day: number, placeId: string) {
+  emit('removePlace', day, placeId);
+}
+
+// 드래그 이벤트 핸들러
+function onDragStart() {
+  isDragging.value = true;
+}
+
+function onDragEnd() {
+  isDragging.value = false;
+}
+
+function getAccommodationIcon(place: PlaceResult): string {
+  if (!place.types) return '🏨';
+
+  // 숙소 유형별 아이콘 매핑
+  for (const type of place.types) {
+    switch (type.toLowerCase()) {
+      case 'hotel':
+      case 'lodging':
+        return '🏨'; // 호텔
+      case 'motel':
+        return '🏩'; // 모텔
+      case 'resort':
+        return '🏖️'; // 리조트
+      case 'campground':
+      case 'rv_park':
+        return '🏕️'; // 캠핑장
+      case 'spa':
+        return '♨️'; // 스파
+      case 'guest_house':
+        return '🏠'; // 게스트하우스
+      case 'hostel':
+        return '🛏️'; // 호스텔
+      case 'apartment':
+      case 'real_estate_agency':
+        return '🏢'; // 아파트/숙박업소
+      default:
+        continue;
+    }
+  }
+
+  // 숙소 이름으로 추가 판단
+  const name = place.name.toLowerCase();
+  if (name.includes('펜션')) return '🏡';
+  if (name.includes('리조트')) return '🏖️';
+  if (name.includes('모텔')) return '🏩';
+  if (name.includes('게스트하우스') || name.includes('민박')) return '🏠';
+  if (name.includes('호스텔')) return '🛏️';
+  if (name.includes('캠핑') || name.includes('글램핑')) return '🏕️';
+  if (name.includes('스파') || name.includes('온천')) return '♨️';
+
+  return '🏨';
+}
 </script>
+
+<style scoped>
+.ghost-card {
+  opacity: 0.5;
+  background: #e3f2fd;
+  border: 2px dashed #2196f3;
+  transform: rotate(2deg);
+}
+
+.chosen-card {
+  opacity: 0.9;
+}
+
+.drag-card {
+  opacity: 0.8;
+  transform: rotate(-2deg);
+  z-index: 1000;
+}
+
+/* 드래그 중일 때 부드러운 트랜지션 */
+.sortable-ghost {
+  opacity: 0.4;
+}
+
+.sortable-chosen {
+  opacity: 0.9;
+}
+
+.sortable-drag {
+  opacity: 0.8;
+}
+</style>

--- a/src/composables/plan/usePlanMap.ts
+++ b/src/composables/plan/usePlanMap.ts
@@ -390,35 +390,34 @@ export function usePlanMap() {
     );
   }
 
-  // 특정 일차의 polyline 업데이트 - 기존 polyline 재사용
+  // 특정 일차의 polyline 업데이트 - 수정된 버전
   function updatePolylineForDay(day: number, dayPlan: DayPlan) {
     if (!map) return;
 
-    // 숙소가 없으면 polyline 제거
-    if (!dayPlan.accommodation) {
-      const existingPolyline = polylines.value.get(day);
-      if (existingPolyline) {
-        console.log(`Day ${day}: 숙소 없음 - polyline 제거`);
-        existingPolyline.setMap(null);
-        polylines.value.delete(day);
-      }
-      return;
-    }
-
-    // 경로 점들 구성 (숙소 -> 장소1 -> 장소2 -> ... -> 숙소)
+    // 경로 점들 구성
     const path: google.maps.LatLngLiteral[] = [];
 
-    // 숙소를 시작점으로 추가
-    path.push(dayPlan.accommodation.location.toJSON());
-
-    // 모든 장소들을 순서대로 추가
-    dayPlan.places.forEach(place => {
-      path.push(place.location.toJSON());
-    });
-
-    // 다시 숙소로 돌아오는 경로 추가 (장소가 하나 이상 있을 때만)
-    if (dayPlan.places.length > 0) {
+    // Case 1: 숙소가 있는 경우
+    if (dayPlan.accommodation) {
+      // 숙소를 시작점으로 추가
       path.push(dayPlan.accommodation.location.toJSON());
+
+      // 모든 장소들을 순서대로 추가
+      dayPlan.places.forEach(place => {
+        path.push(place.location.toJSON());
+      });
+
+      // 다시 숙소로 돌아오는 경로 추가 (장소가 하나 이상 있을 때만)
+      if (dayPlan.places.length > 0) {
+        path.push(dayPlan.accommodation.location.toJSON());
+      }
+    }
+    // Case 2: 숙소가 없는 경우 - 장소들끼리만 연결
+    else {
+      // 장소들을 순서대로 연결
+      dayPlan.places.forEach(place => {
+        path.push(place.location.toJSON());
+      });
     }
 
     // 경로가 2개 미만이면 polyline 제거

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -60,11 +60,6 @@ const router = createRouter({
       name: 'plan',
       component: () => import('@/views/PlanView.vue'),
     },
-    {
-      path: '/test',
-      name: 'test',
-      component: () => import('@/views/TestView.vue'),
-    },
     // 도시 정보와 함께 여행 계획 페이지로 이동
     {
       path: '/plan/:cityId/:cityEn/:cityKo',
@@ -73,7 +68,6 @@ const router = createRouter({
       props: true,
       meta: { requiresAuth: true }, // 로그인 필요
     },
-
   ],
 });
 

--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -101,7 +101,7 @@
 </template>
 
 <script setup lang="ts">
-import { watch, onMounted, ref } from 'vue';
+import { watch, onMounted, ref, nextTick } from 'vue';
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next';
 import { usePlanStore } from '@/stores/plan';
 import { useRoute } from 'vue-router';
@@ -205,7 +205,11 @@ function handleOrderChanged(day: number) {
   // 해당 일차의 DayPlan을 가져와서 지도 업데이트
   const dayPlan = planStore.dayPlans[day];
   if (dayPlan) {
-    updateMarkersForDayPlan(day, dayPlan);
+    // setTimeout 사용 지양하고 Vue의 nextTick을 사용
+    // 반응성 업데이트가 완료된 후 실행
+    nextTick(() => {
+      updateMarkersForDayPlan(day, planStore.dayPlans[day]);
+    });
   }
 }
 

--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -68,8 +68,8 @@
       >
         <button
           class="absolute left-0 h-10 rounded-r-md bg-white px-2 py-2 text-gray-400"
-          @click="planStore.toggleDrawer()"
           style="z-index: 11"
+          @click="planStore.toggleDrawer()"
         >
           <ChevronLeft v-if="planStore.drawerOpen" class="h-5 w-5" />
           <ChevronRight v-else class="h-5 w-5" />
@@ -188,7 +188,8 @@ function handlePlaceClick(place: PlaceResult) {
 
 function handleRemovePlace(day: number, placeId: string) {
   planStore.removePlaceFromDay(day, placeId);
-  removeMarkerForDay(day, placeId);
+  // dayPlan 전달 추가
+  removeMarkerForDay(day, placeId, planStore.dayPlans[day]);
 }
 
 // Step 3용 숙소 모달 열기
@@ -218,12 +219,13 @@ function handleAccommodationConfirm(days: number[], place: PlaceResult) {
     // 기존 숙소가 있다면 마커 제거
     const existingAccommodation = planStore.dayPlans[day]?.accommodation;
     if (existingAccommodation) {
-      removeMarkerForDay(day, existingAccommodation.placeId);
+      removeMarkerForDay(day, existingAccommodation.placeId, planStore.dayPlans[day]);
     }
 
     // 새 숙소 추가
     planStore.addAccommodationToDay(day, place);
-    addMarkerForDay(day, place, 'accommodation');
+    // dayPlan 전달 추가
+    addMarkerForDay(day, place, 'accommodation', planStore.dayPlans[day]);
   });
 
   selectedAccommodationPlace.value = null;
@@ -232,7 +234,8 @@ function handleAccommodationConfirm(days: number[], place: PlaceResult) {
 // Step 4용 장소 확인 핸들러
 function handlePlaceConfirm(day: number, place: PlaceResult) {
   planStore.addPlaceToDay(day, place);
-  addMarkerForDay(day, place, planStore.dayPlans[day].places.length);
+  // dayPlan 전달 추가
+  addMarkerForDay(day, place, planStore.dayPlans[day].places.length, planStore.dayPlans[day]);
   selectedPlace.value = null;
 }
 

--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -13,11 +13,13 @@
           v-else-if="planStore.currentStep === 3"
           @accommodation-click="handlePlaceClick"
           @remove-accommodation="handleRemovePlace"
+          @order-changed="handleOrderChanged"
         />
         <Step4PlaceSearch
           v-else-if="planStore.currentStep === 4"
           @place-click="handlePlaceClick"
           @remove-place="handleRemovePlace"
+          @order-changed="handleOrderChanged"
         />
       </div>
 
@@ -130,8 +132,14 @@ const route = useRoute();
 const cityName = ref((route.params.cityName as string) || '서울');
 
 // 지도 초기화
-const { initMap, moveToLocation, addMarkerForDay, removeMarkerForDay, showMarkerForSearchClick } =
-  usePlanMap();
+const {
+  initMap,
+  moveToLocation,
+  addMarkerForDay,
+  removeMarkerForDay,
+  showMarkerForSearchClick,
+  updateMarkersForDayPlan,
+} = usePlanMap();
 
 // 모달 관련 상태 - 분리됨
 const selectedAccommodationPlace = ref<PlaceResult | null>(null);
@@ -190,6 +198,15 @@ function handleRemovePlace(day: number, placeId: string) {
   planStore.removePlaceFromDay(day, placeId);
   // dayPlan 전달 추가
   removeMarkerForDay(day, placeId, planStore.dayPlans[day]);
+}
+
+// 🆕 순서 변경 핸들러 - 드래그 앤 드롭으로 순서가 바뀔 때 호출
+function handleOrderChanged(day: number) {
+  // 해당 일차의 DayPlan을 가져와서 지도 업데이트
+  const dayPlan = planStore.dayPlans[day];
+  if (dayPlan) {
+    updateMarkersForDayPlan(day, dayPlan);
+  }
 }
 
 // Step 3용 숙소 모달 열기


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
경로 그리기 기능 및 장소 draggable 적용 

## 📌 이슈 넘버
- #20 

## 📝 작업 내용

- 장소를 드래그하여 순서를 변경할 수 있도록 draggable 기능 구현
- 드래그에 따라 마커 번호 및 경로(Polyline)가 실시간으로 업데이트되도록 처리
- 마커 클릭 및 선택 시에도 동일한 번호 및 경로 갱신 로직 적용
- 경로 그리기(Polyline) 로직 추가
- polyline 중복관련 트러블 슈팅 -> [팀 노션에 정리](https://www.notion.so/Vue-js-Google-Maps-Polyline-1fea66188f288010b7d5c8fa7c1b6c5c?pvs=4)


## 📸 스크린샷(선택)
경로 업데이트 gif
1. 장소 추가
![장소추가시 경로업데이트](https://github.com/user-attachments/assets/a5624ebc-7eb3-4f4c-9658-8ba537853266)
2. 장소 삭제
![삭제 시 경로 업데이트](https://github.com/user-attachments/assets/82ac79e5-5253-4a4c-81dd-8a1429d26793)
3. 숙소만 삭제 시
![숙소삭제시 경로업데이트](https://github.com/user-attachments/assets/fc9b45c9-8d73-40cb-88c9-12bdb0c4c7fa)
4. draggable시  순서 변경, day 넘어서 변경
![draggable적용시업데이트 (1)](https://github.com/user-attachments/assets/6e0a5fd8-3fac-4420-9d7b-89536ea007e3)


## 💬리뷰 요구사항(선택)

이제 api 연동 남앗습니다....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
    - 숙소 선택 UI가 개선되어 날짜별 뱃지, 숙소 상태, 아이콘, 삭제 버튼 및 안내 문구가 추가되었습니다.
    - 일정별 장소 관리 UI가 개선되고, 드래그 앤 드롭으로 장소 순서를 변경할 수 있습니다.
    - 숙소 및 장소에 맞는 아이콘이 표시됩니다.
    - 지도에서 하루 단위로 경로(폴리라인) 표시가 추가되었습니다.

- **버그 수정**
    - 장소 순서 변경 시 지도 마커와 경로가 정확히 갱신됩니다.

- **기타**
    - 테스트용 라우트(/test)가 제거되었습니다.
    - UI 안내 및 빈 상태 메시지가 시각적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->