### PR TITLE
[Refac] ai 마크다운 프리뷰 생성

### DIFF
--- a/src/components/views/recordDetail/AiStoryContent.vue
+++ b/src/components/views/recordDetail/AiStoryContent.vue
@@ -1,0 +1,186 @@
+<!-- src/components/AiStoryContent.vue -->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Textarea } from '@/components/ui/textarea';
+import { Eye, Code } from 'lucide-vue-next';
+
+interface Props {
+  isEditing: boolean;
+  editableContent: string;
+  aiStoryContent: string | null;
+  showPreview: boolean;
+  editViewMode: 'split' | 'edit' | 'preview';
+  isSavingStory: boolean;
+  hasChanges: boolean;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits(['update:editableContent']);
+
+// 마크다운을 HTML로 변환하는 함수
+const convertMarkdownToHtml = (markdown: string): string => {
+  if (!markdown) return '';
+
+  return (
+    markdown
+      // 헤더 변환
+      .replace(/^### (.*$)/gim, '<h3 class="text-lg font-bold text-gray-800 mt-6 mb-3">$1</h3>')
+      .replace(/^## (.*$)/gim, '<h2 class="text-xl font-bold text-gray-800 mt-8 mb-4">$1</h2>')
+      .replace(/^# (.*$)/gim, '<h1 class="text-2xl font-bold text-gray-800 mt-8 mb-6">$1</h1>')
+
+      // 볼드/이탤릭
+      .replace(/\*\*(.*?)\*\*/g, '<strong class="font-semibold text-gray-900">$1</strong>')
+      .replace(/\*(.*?)\*/g, '<em class="italic text-gray-700">$1</em>')
+
+      // 리스트
+      .replace(/^\- (.*$)/gim, '<li class="ml-4 text-gray-700">• $1</li>')
+
+      // 줄바꿈
+      .replace(/\n\n/g, '</p><p class="text-gray-700 leading-relaxed mb-4">')
+      .replace(/\n/g, '<br>')
+
+      // 전체를 p 태그로 감싸기
+      .replace(/^(.*)$/, '<p class="text-gray-700 leading-relaxed mb-4">$1</p>')
+  );
+};
+
+const previewHtml = computed(() => {
+  const content = props.isEditing ? props.editableContent : props.aiStoryContent || '';
+  return convertMarkdownToHtml(content);
+});
+
+const updateEditableContent = (value: string) => {
+  emit('update:editableContent', value);
+};
+</script>
+
+<template>
+  <!-- 컨텐츠 영역 -->
+  <div class="bg-gradient-to-br from-gray-50 to-purple-50 p-6">
+    <!-- 편집 모드 -->
+    <div v-if="isEditing">
+      <!-- Split View -->
+      <div v-if="editViewMode === 'split'" class="grid grid-cols-2 gap-4">
+        <!-- 편집 패널 -->
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-gray-700">
+            <Code class="h-4 w-4" />
+            마크다운 편집
+          </div>
+          <Textarea
+            :model-value="editableContent"
+            @update:model-value="updateEditableContent"
+            :disabled="isSavingStory"
+            class="min-h-96 w-full resize-none border-gray-200 focus:border-purple-500 focus:ring-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder="여행 스토리를 입력하세요..."
+          />
+        </div>
+
+        <!-- 프리뷰 패널 -->
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-gray-700">
+            <Eye class="h-4 w-4" />
+            실시간 프리뷰
+          </div>
+          <div class="min-h-96 overflow-y-auto rounded-md border border-gray-200 bg-white p-4">
+            <div
+              v-if="editableContent.trim()"
+              v-html="previewHtml"
+              class="prose prose-sm max-w-none"
+            ></div>
+            <div v-else class="flex h-full items-center justify-center text-gray-400">
+              <div class="text-center">
+                <Eye class="mx-auto mb-2 h-8 w-8 opacity-50" />
+                <p>마크다운을 입력하면 실시간으로 프리뷰가 표시됩니다</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Edit Only View -->
+      <div v-else-if="editViewMode === 'edit'">
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-gray-700">
+            <Code class="h-4 w-4" />
+            마크다운 편집
+          </div>
+          <Textarea
+            :model-value="editableContent"
+            @update:model-value="updateEditableContent"
+            :disabled="isSavingStory"
+            class="min-h-96 w-full resize-none border-gray-200 focus:border-purple-500 focus:ring-purple-500 disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder="여행 스토리를 입력하세요..."
+          />
+        </div>
+      </div>
+
+      <!-- Preview Only View -->
+      <div v-else-if="editViewMode === 'preview'">
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-gray-700">
+            <Eye class="h-4 w-4" />
+            프리뷰
+          </div>
+          <div class="min-h-96 overflow-y-auto rounded-md border border-gray-200 bg-white p-6">
+            <div v-if="editableContent.trim()" v-html="previewHtml" class="prose max-w-none"></div>
+            <div v-else class="flex h-full items-center justify-center text-gray-400">
+              <div class="text-center">
+                <Eye class="mx-auto mb-2 h-8 w-8 opacity-50" />
+                <p>입력된 마크다운이 없습니다</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 편집 모드 상태 표시 -->
+      <div class="mt-4 flex items-center justify-between text-sm text-gray-500">
+        <div class="flex items-center gap-4">
+          <span>{{ editableContent.length }} 글자</span>
+          <span v-if="hasChanges && !isSavingStory" class="text-purple-600">
+            • 변경사항이 있습니다
+          </span>
+          <span v-if="isSavingStory" class="text-orange-600">• 저장 중...</span>
+        </div>
+
+        <!-- 저장 진행률 표시 -->
+        <div v-if="isSavingStory" class="flex items-center gap-2 text-purple-600">
+          <div class="flex space-x-1">
+            <div class="h-2 w-2 animate-pulse rounded-full bg-purple-600"></div>
+            <div
+              class="h-2 w-2 animate-pulse rounded-full bg-purple-600"
+              style="animation-delay: 0.2s"
+            ></div>
+            <div
+              class="h-2 w-2 animate-pulse rounded-full bg-purple-600"
+              style="animation-delay: 0.4s"
+            ></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 읽기 모드 -->
+    <div v-else>
+      <!-- Raw/Preview 토글 표시 -->
+      <div class="mb-4 flex items-center gap-2 text-sm font-medium text-gray-700">
+        <component :is="showPreview ? Eye : Code" class="h-4 w-4" />
+        <span>{{ showPreview ? '마크다운 프리뷰' : '마크다운 원본' }}</span>
+      </div>
+
+      <!-- 원본 마크다운 표시 -->
+      <div
+        v-if="!showPreview"
+        class="rounded-md border border-gray-200 bg-white p-4 leading-relaxed whitespace-pre-wrap text-gray-700"
+      >
+        {{ editableContent }}
+      </div>
+
+      <!-- 프리뷰 표시 -->
+      <div v-else class="rounded-md border border-gray-200 bg-white p-6">
+        <div v-html="previewHtml" class="prose max-w-none"></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/views/recordDetail/AiStoryEmpty.vue
+++ b/src/components/views/recordDetail/AiStoryEmpty.vue
@@ -1,0 +1,69 @@
+<!-- src/components/AiStoryEmpty.vue -->
+<script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import { Sparkles } from 'lucide-vue-next';
+
+interface Props {
+  isGeneratingStory: boolean;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits(['generate']);
+
+const handleGenerate = () => {
+  emit('generate');
+};
+</script>
+
+<template>
+  <!-- 그라데이션 배경 컨테이너 -->
+  <div
+    class="rounded-2xl border border-gray-100 bg-gradient-to-br from-gray-50 to-purple-50 p-8 text-center"
+  >
+    <div class="mb-6">
+      <!-- 그라데이션 아이콘 컨테이너 -->
+      <div
+        class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-purple-100 to-blue-100"
+      >
+        <Sparkles class="h-8 w-8 text-purple-600" />
+      </div>
+
+      <!-- 상태에 따른 메시지 표시 -->
+      <div v-if="isGeneratingStory">
+        <p class="text-gray-700">AI가 여행 기록을 분석하고 있어요... 잠시만 기다려주세요</p>
+        <p class="mt-1 text-sm text-gray-600">멋진 스토리를 만들어드릴게요</p>
+      </div>
+      <div v-else>
+        <p class="text-gray-700">아직 생성된 여행 스토리가 없습니다.</p>
+        <p class="mt-1 text-sm text-gray-600">AI가 당신의 여행을 감동적인 이야기로 만들어드려요</p>
+      </div>
+    </div>
+
+    <!-- 그라데이션 생성 버튼 -->
+    <Button
+      @click="handleGenerate"
+      :disabled="isGeneratingStory"
+      class="inline-flex items-center gap-3 bg-gradient-to-r from-purple-600 to-blue-600 px-6 py-3 text-white shadow-lg transition-all hover:from-purple-700 hover:to-blue-700 hover:shadow-xl disabled:opacity-50"
+      size="lg"
+    >
+      <Sparkles class="h-5 w-5" :class="{ 'animate-spin': isGeneratingStory }" />
+      <span v-if="isGeneratingStory" class="font-medium">마법을 부리는 중...</span>
+      <span v-else class="font-medium">AI 스토리 생성하기</span>
+    </Button>
+
+    <!-- 진행 상황 표시 (생성 중일 때) -->
+    <div v-if="isGeneratingStory" class="mt-4 text-sm text-gray-600">
+      <div class="flex items-center justify-center gap-2">
+        <div class="h-2 w-2 animate-pulse rounded-full bg-purple-400"></div>
+        <div
+          class="h-2 w-2 animate-pulse rounded-full bg-purple-400"
+          style="animation-delay: 0.2s"
+        ></div>
+        <div
+          class="h-2 w-2 animate-pulse rounded-full bg-purple-400"
+          style="animation-delay: 0.4s"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/views/recordDetail/AiStoryHeader.vue
+++ b/src/components/views/recordDetail/AiStoryHeader.vue
@@ -1,0 +1,298 @@
+<!-- src/components/AiStoryHeader.vue -->
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Trash2,
+  RefreshCw,
+  Sparkles,
+  Edit3,
+  Save,
+  X,
+  Copy,
+  Eye,
+  Code,
+  SplitSquareHorizontal,
+  AlertTriangle,
+} from 'lucide-vue-next';
+
+interface Props {
+  isEditing: boolean;
+  isGeneratingStory: boolean;
+  isSavingStory: boolean;
+  isDeletingStory: boolean;
+  showPreview: boolean;
+  editViewMode: 'split' | 'edit' | 'preview';
+  hasChanges: boolean;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits([
+  'startEditing',
+  'saveStory',
+  'cancelEditing',
+  'copyToClipboard',
+  'togglePreview',
+  'setEditViewMode',
+  'regenerateStory',
+  'deleteStory',
+]);
+
+const isDeleteDialogOpen = ref(false);
+const isRegenerateDialogOpen = ref(false);
+
+const handleStartEditing = () => emit('startEditing');
+const handleSaveStory = () => emit('saveStory');
+const handleCancelEditing = () => emit('cancelEditing');
+const handleCopyToClipboard = () => emit('copyToClipboard');
+const handleTogglePreview = () => emit('togglePreview');
+const handleSetEditViewMode = (mode: 'split' | 'edit' | 'preview') => emit('setEditViewMode', mode);
+const handleRegenerateStory = () => {
+  emit('regenerateStory');
+  isRegenerateDialogOpen.value = false;
+};
+const handleDeleteStory = () => {
+  emit('deleteStory');
+  isDeleteDialogOpen.value = false;
+};
+</script>
+
+<template>
+  <!-- 그라데이션 헤더 with 액션 버튼들 -->
+  <div class="bg-gradient-to-r from-purple-500 to-blue-600 px-6 py-4">
+    <div class="flex items-center justify-between">
+      <h3 class="flex items-center gap-2 text-lg font-semibold text-white">
+        <Sparkles class="h-5 w-5" />
+        나만의 여행 스토리
+      </h3>
+
+      <!-- 액션 버튼들 -->
+      <div class="flex items-center gap-2">
+        <!-- 복사 버튼 (항상 표시) -->
+        <Button
+          @click="handleCopyToClipboard"
+          :disabled="isGeneratingStory || isDeletingStory || isSavingStory"
+          size="sm"
+          variant="ghost"
+          class="hover:bg-opacity-20 text-white hover:bg-white"
+          title="클립보드에 복사"
+        >
+          <Copy class="h-4 w-4" />
+        </Button>
+
+        <!-- 편집 모드가 아닐 때 -->
+        <template v-if="!isEditing">
+          <Button
+            @click="handleStartEditing"
+            :disabled="isGeneratingStory || isDeletingStory || isSavingStory"
+            size="sm"
+            variant="ghost"
+            class="hover:bg-opacity-20 text-white hover:bg-white"
+          >
+            <Edit3 class="h-4 w-4" />
+          </Button>
+
+          <!-- 프리뷰/Raw 토글 버튼 -->
+          <Button
+            @click="handleTogglePreview"
+            :disabled="isGeneratingStory || isDeletingStory || isSavingStory"
+            size="sm"
+            variant="ghost"
+            class="hover:bg-opacity-20 text-white hover:bg-white"
+            :title="showPreview ? '마크다운 원본 보기' : '마크다운 프리뷰 보기'"
+          >
+            <Eye v-if="!showPreview" class="h-4 w-4" />
+            <Code v-else class="h-4 w-4" />
+          </Button>
+
+          <Button
+            @click="isRegenerateDialogOpen = true"
+            :disabled="isGeneratingStory || isDeletingStory || isSavingStory"
+            size="sm"
+            variant="ghost"
+            class="hover:bg-opacity-20 text-white hover:bg-white"
+          >
+            <RefreshCw class="h-4 w-4" :class="{ 'animate-spin': isGeneratingStory }" />
+          </Button>
+
+          <!-- 재생성 Dialog -->
+          <Dialog v-model:open="isRegenerateDialogOpen">
+            <DialogContent class="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle class="flex items-center gap-2">
+                  <RefreshCw class="h-5 w-5 text-blue-500" />
+                  스토리를 재생성하시겠어요?
+                </DialogTitle>
+                <DialogDescription class="text-gray-600">
+                  이전 기록이 삭제되고 AI가 새로운 스토리를 생성합니다.
+                  <br />
+                  현재 스토리는 복구할 수 없습니다. 정말로 재생성하시겠어요?
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter class="flex-col-reverse gap-2 sm:flex-row">
+                <Button
+                  variant="outline"
+                  @click="isRegenerateDialogOpen = false"
+                  :disabled="isGeneratingStory"
+                  class="w-full sm:w-auto"
+                >
+                  취소
+                </Button>
+                <Button
+                  @click="handleRegenerateStory"
+                  :disabled="isGeneratingStory"
+                  class="w-full bg-blue-600 text-white hover:bg-blue-700 sm:w-auto"
+                >
+                  <RefreshCw class="mr-2 h-4 w-4" :class="{ 'animate-spin': isGeneratingStory }" />
+                  <span v-if="isGeneratingStory">재생성 중...</span>
+                  <span v-else>재생성하기</span>
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <!-- 삭제 Dialog -->
+          <Dialog v-model:open="isDeleteDialogOpen">
+            <DialogTrigger asChild>
+              <Button
+                :disabled="isGeneratingStory || isDeletingStory || isSavingStory"
+                size="sm"
+                variant="ghost"
+                class="hover:bg-opacity-20 text-white hover:bg-red-500"
+              >
+                <Trash2 class="h-4 w-4" />
+              </Button>
+            </DialogTrigger>
+            <DialogContent class="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle class="flex items-center gap-2">
+                  <AlertTriangle class="h-5 w-5 text-red-500" />
+                  스토리를 삭제하시겠어요?
+                </DialogTitle>
+                <DialogDescription class="text-gray-600">
+                  이 작업은 되돌릴 수 없습니다.
+                  <br />
+                  소중한 여행 스토리가 영원히 삭제됩니다. 정말로 삭제하시겠어요?
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter class="flex-col-reverse gap-2 sm:flex-row">
+                <Button
+                  variant="outline"
+                  @click="isDeleteDialogOpen = false"
+                  :disabled="isDeletingStory"
+                  class="w-full sm:w-auto"
+                >
+                  취소
+                </Button>
+                <Button
+                  variant="destructive"
+                  @click="handleDeleteStory"
+                  :disabled="isDeletingStory"
+                  class="w-full sm:w-auto"
+                >
+                  <Trash2 class="mr-2 h-4 w-4" :class="{ 'animate-bounce': isDeletingStory }" />
+                  <span v-if="isDeletingStory">삭제 중...</span>
+                  <span v-else>삭제</span>
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </template>
+
+        <!-- 편집 모드일 때 -->
+        <template v-else>
+          <!-- 편집 뷰 모드 토글 버튼들 -->
+          <div class="flex rounded-md bg-white/20 p-1">
+            <Button
+              @click="handleSetEditViewMode('edit')"
+              :variant="editViewMode === 'edit' ? 'default' : 'ghost'"
+              size="sm"
+              class="h-8 px-2 text-xs"
+              :class="
+                editViewMode === 'edit'
+                  ? 'bg-white text-purple-600'
+                  : 'text-white hover:bg-white/20'
+              "
+            >
+              <Code class="h-3 w-3" />
+            </Button>
+            <Button
+              @click="handleSetEditViewMode('split')"
+              :variant="editViewMode === 'split' ? 'default' : 'ghost'"
+              size="sm"
+              class="h-8 px-2 text-xs"
+              :class="
+                editViewMode === 'split'
+                  ? 'bg-white text-purple-600'
+                  : 'text-white hover:bg-white/20'
+              "
+            >
+              <SplitSquareHorizontal class="h-3 w-3" />
+            </Button>
+            <Button
+              @click="handleSetEditViewMode('preview')"
+              :variant="editViewMode === 'preview' ? 'default' : 'ghost'"
+              size="sm"
+              class="h-8 px-2 text-xs"
+              :class="
+                editViewMode === 'preview'
+                  ? 'bg-white text-purple-600'
+                  : 'text-white hover:bg-white/20'
+              "
+            >
+              <Eye class="h-3 w-3" />
+            </Button>
+          </div>
+
+          <Button
+            @click="handleSaveStory"
+            :disabled="isSavingStory || !hasChanges"
+            size="sm"
+            variant="ghost"
+            class="hover:bg-opacity-20 text-white hover:bg-green-500 disabled:opacity-50"
+          >
+            <Save class="h-4 w-4" :class="{ 'animate-pulse': isSavingStory }" />
+          </Button>
+
+          <Button
+            @click="handleCancelEditing"
+            :disabled="isSavingStory"
+            size="sm"
+            variant="ghost"
+            class="hover:bg-opacity-20 text-white hover:bg-red-500"
+          >
+            <X class="h-4 w-4" />
+          </Button>
+        </template>
+      </div>
+    </div>
+
+    <!-- 편집/저장 모드 상태 표시 -->
+    <div
+      v-if="isEditing || isSavingStory"
+      class="text-opacity-90 mt-2 flex items-center gap-2 text-sm text-white"
+    >
+      <Edit3 v-if="isEditing && !isSavingStory" class="h-4 w-4" />
+      <div
+        v-if="isSavingStory"
+        class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+      ></div>
+      <span v-if="isSavingStory">저장 중...</span>
+      <span v-else-if="isEditing">
+        편집 모드 -
+        <span v-if="editViewMode === 'edit'">마크다운 편집</span>
+        <span v-else-if="editViewMode === 'split'">분할 뷰</span>
+        <span v-else>프리뷰 모드</span>
+      </span>
+    </div>
+  </div>
+</template>

--- a/src/components/views/recordDetail/TripRecordCard.vue
+++ b/src/components/views/recordDetail/TripRecordCard.vue
@@ -95,7 +95,7 @@ const formatDate = (date: Date): string => {
         </label>
         <Textarea
           v-model="cardMemo"
-          placeholder="이 날의 여행 경험과 느낌을 자유롭게 기록해보세요...&#10;&#10;예시:&#10;- 오늘 방문한 장소들의 인상&#10;- 맛있었던 음식이나 특별한 경험&#10;- 함께한 사람들과의 추억"
+          placeholder="이 날의 여행 경험과 느낌을 기록해보세요...&#10;&#10;예시:&#10;- 오늘 방문한 장소들의 인상&#10;- 맛있었던 음식이나 특별한 경험&#10;- 함께한 사람들과의 추억"
           class="h-32 resize-none rounded-lg border-0 bg-gray-50 text-sm leading-relaxed"
           @input="handleMemoUpdate"
         />


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
> ai 마크다운 프리뷰 생성

## 📝 작업 내용
- 마크다운 프리뷰 생성
- 복사 기능 추가

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/169b957e-8c95-41f7-9e83-303faf92a58a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - AI 스토리 아코디언 뷰를 헤더, 콘텐츠, 비어있음 등 세부 컴포넌트로 분리하여 UI 구조를 개선했습니다.

- **New Features**
  - AI 스토리 콘텐츠 편집 및 미리보기, 상태 표시, 캐릭터 수 등 다양한 편집 인터페이스가 추가되었습니다.
  - 스토리 미생성 시 AI 스토리 생성 안내 및 진행 상태 표시 UI가 추가되었습니다.
  - 스토리 관리(복사, 편집, 저장, 취소, 미리보기, 재생성, 삭제 등) 기능이 헤더에서 직관적으로 제공됩니다.

- **Style**
  - 각 컴포넌트에 시각적 효과와 애니메이션이 적용되어 사용자 경험이 향상되었습니다.

- **Chores**
  - 여행 기록 카드의 입력란 플레이스홀더에 미세한 포맷팅 변경이 있었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->