### PR TITLE
[FEAT] 계획 디테일페이지 구현

### DIFF
--- a/src/components/plan/CustomStepper.vue
+++ b/src/components/plan/CustomStepper.vue
@@ -39,7 +39,6 @@
     </Button>
   </div>
 </template>
-
 <script setup lang="ts">
 import { Button } from '@/components/ui/button';
 import { Stepper, StepperItem, StepperTrigger } from '@/components/ui/stepper';
@@ -61,6 +60,11 @@ const handleStepAction = async () => {
 
       // 성공시 결과 페이지로 이동 또는 성공 메시지 표시
       alert(`여행 계획이 성공적으로 생성되었습니다! (Trip ID: ${tripId})`);
+
+      // 성공시 디테일 페이지로 이동
+      await router.push({
+        path: `/plan/${tripId}`,
+      });
 
       // 필요시 다른 페이지로 라우팅
       // router.push(`/trip/${tripId}`);

--- a/src/components/plan/CustomStepper.vue
+++ b/src/components/plan/CustomStepper.vue
@@ -35,7 +35,7 @@
       class="mb-4 bg-black p-6 text-white hover:bg-black/80"
       @click="handleStepAction"
     >
-      {{ planStore.isSubmitting ? '처리중...' : planStore.currentStep === 4 ? '완료' : '다음' }}
+      {{ planStore.isSubmitting ? '⏳' : planStore.currentStep === 4 ? '완료' : '다음' }}
     </Button>
   </div>
 </template>

--- a/src/components/plan/Step1DateSetting.vue
+++ b/src/components/plan/Step1DateSetting.vue
@@ -295,14 +295,6 @@ const confirmDateSelection = () => {
       start: planStore.tempDateRange.start,
       end: planStore.tempDateRange.end,
     });
-    // 백엔드에 전송할 수 있는 형태로 변환
-    const startDate = planStore.selectedDateRange.start?.toISOString();
-    const endDate = planStore.selectedDateRange.end?.toISOString();
-
-    console.log('선택된 여행 기간:', {
-      startDate,
-      endDate,
-    });
 
     // 단계 이동을 먼저 하고 모달을 닫음
     planStore.nextStep();

--- a/src/components/ui/badge/Badge.vue
+++ b/src/components/ui/badge/Badge.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { Primitive } from 'reka-ui'
+import { cn } from '@/lib/shadcn/utils'
+import { type BadgeVariants, badgeVariants } from '.'
+
+const props = defineProps<PrimitiveProps & {
+  variant?: BadgeVariants['variant']
+  class?: HTMLAttributes['class']
+}>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+</script>
+
+<template>
+  <Primitive
+    data-slot="badge"
+    :class="cn(badgeVariants({ variant }), props.class)"
+    v-bind="delegatedProps"
+  >
+    <slot />
+  </Primitive>
+</template>

--- a/src/components/ui/badge/index.ts
+++ b/src/components/ui/badge/index.ts
@@ -1,0 +1,25 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export { default as Badge } from './Badge.vue'
+
+export const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+         'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+export type BadgeVariants = VariantProps<typeof badgeVariants>

--- a/src/components/ui/resizable/ResizableHandle.vue
+++ b/src/components/ui/resizable/ResizableHandle.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { GripVertical } from 'lucide-vue-next'
+import { SplitterResizeHandle, type SplitterResizeHandleEmits, type SplitterResizeHandleProps, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/shadcn/utils'
+
+const props = defineProps<SplitterResizeHandleProps & { class?: HTMLAttributes['class'], withHandle?: boolean }>()
+const emits = defineEmits<SplitterResizeHandleEmits>()
+
+const delegatedProps = reactiveOmit(props, 'class', 'withHandle')
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <SplitterResizeHandle
+    data-slot="resizable-handle"
+    v-bind="forwarded"
+    :class="cn('bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[orientation=vertical]:h-px data-[orientation=vertical]:w-full data-[orientation=vertical]:after:left-0 data-[orientation=vertical]:after:h-1 data-[orientation=vertical]:after:w-full data-[orientation=vertical]:after:-translate-y-1/2 data-[orientation=vertical]:after:translate-x-0 [&[data-orientation=vertical]>div]:rotate-90', props.class)"
+  >
+    <template v-if="props.withHandle">
+      <div class="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+        <GripVertical class="size-2.5" />
+      </div>
+    </template>
+  </SplitterResizeHandle>
+</template>

--- a/src/components/ui/resizable/ResizablePanel.vue
+++ b/src/components/ui/resizable/ResizablePanel.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { SplitterPanelEmits, SplitterPanelProps } from 'reka-ui'
+import { SplitterPanel, useForwardPropsEmits } from 'reka-ui'
+
+const props = defineProps<SplitterPanelProps>()
+const emits = defineEmits<SplitterPanelEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <SplitterPanel
+    data-slot="resizable-panel"
+    v-bind="forwarded"
+  >
+    <slot />
+  </SplitterPanel>
+</template>

--- a/src/components/ui/resizable/ResizablePanelGroup.vue
+++ b/src/components/ui/resizable/ResizablePanelGroup.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { SplitterGroup, type SplitterGroupEmits, type SplitterGroupProps, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/shadcn/utils'
+
+const props = defineProps<SplitterGroupProps & { class?: HTMLAttributes['class'] }>()
+const emits = defineEmits<SplitterGroupEmits>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <SplitterGroup
+    data-slot="resizable-panel-group"
+    v-bind="forwarded"
+    :class="cn('flex h-full w-full data-[orientation=vertical]:flex-col', props.class)"
+  >
+    <slot />
+  </SplitterGroup>
+</template>

--- a/src/components/ui/resizable/index.ts
+++ b/src/components/ui/resizable/index.ts
@@ -1,0 +1,3 @@
+export { default as ResizableHandle } from './ResizableHandle.vue'
+export { default as ResizablePanel } from './ResizablePanel.vue'
+export { default as ResizablePanelGroup } from './ResizablePanelGroup.vue'

--- a/src/components/ui/separator/Separator.vue
+++ b/src/components/ui/separator/Separator.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { Separator, type SeparatorProps } from 'reka-ui'
+import { cn } from '@/lib/shadcn/utils'
+
+const props = withDefaults(defineProps<
+  SeparatorProps & { class?: HTMLAttributes['class'] }
+>(), {
+  orientation: 'horizontal',
+  decorative: true,
+})
+
+const delegatedProps = reactiveOmit(props, 'class')
+</script>
+
+<template>
+  <Separator
+    data-slot="separator-root"
+    v-bind="delegatedProps"
+    :class="
+      cn(
+        `bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px`,
+        props.class,
+      )
+    "
+  />
+</template>

--- a/src/components/ui/separator/index.ts
+++ b/src/components/ui/separator/index.ts
@@ -1,0 +1,1 @@
+export { default as Separator } from './Separator.vue'

--- a/src/constants/cityMapConfig.ts
+++ b/src/constants/cityMapConfig.ts
@@ -1,4 +1,13 @@
 // @/config/cityMapConfig.ts - 도시별 지도 초기 설정
+
+// 도시 크기 분류
+export enum CitySize {
+  SMALL = 'small', // 작은 도시/관광지 (예: 경주, 강릉, 전주)
+  MEDIUM = 'medium', // 중간 규모 도시 (예: 부산, 대전, 인천)
+  LARGE = 'large', // 대도시 (예: 서울, 도쿄, 뉴욕)
+  EXTRA_LARGE = 'extra_large', // 메가시티/광역도시 (예: 로스앤젤레스, 하와이)
+}
+
 interface CityMapConfig {
   cityId: number;
   cityKo: string;
@@ -9,6 +18,20 @@ interface CityMapConfig {
   };
   zoom: number;
   searchKeyword?: string; // 지오코딩 검색시 사용할 키워드
+  size: CitySize; // 도시 크기 정보 추가
+}
+
+// 도시 크기별 기본 줌 레벨 설정
+export const ZOOM_LEVELS = {
+  [CitySize.SMALL]: 14, // 작은 도시는 더 자세히
+  [CitySize.MEDIUM]: 12.5, // 중간 도시는 적당히
+  [CitySize.LARGE]: 11, // 큰 도시는 넓게
+  [CitySize.EXTRA_LARGE]: 10, // 메가시티는 매우 넓게
+};
+
+// 동적 줌 레벨 계산 함수
+export function calculateDynamicZoom(cityConfig: CityMapConfig): number {
+  return ZOOM_LEVELS[cityConfig.size] || ZOOM_LEVELS[CitySize.MEDIUM];
 }
 
 export const cityMapConfigs: Record<number, CityMapConfig> = {
@@ -20,6 +43,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 34.6937, lng: 135.5023 },
     zoom: 12,
     searchKeyword: 'Osaka, Japan',
+    size: CitySize.MEDIUM,
   },
   2: {
     cityId: 2,
@@ -28,6 +52,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 35.6762, lng: 139.6503 },
     zoom: 12,
     searchKeyword: 'Tokyo, Japan',
+    size: CitySize.LARGE,
   },
   3: {
     cityId: 3,
@@ -36,6 +61,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 33.5904, lng: 130.4017 },
     zoom: 12,
     searchKeyword: 'Fukuoka, Japan',
+    size: CitySize.MEDIUM,
   },
 
   // 한국
@@ -46,6 +72,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 33.4996, lng: 126.5312 },
     zoom: 11,
     searchKeyword: 'Jeju Island, South Korea',
+    size: CitySize.LARGE,
   },
   5: {
     cityId: 5,
@@ -54,6 +81,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 35.1796, lng: 129.0756 },
     zoom: 12,
     searchKeyword: 'Busan, South Korea',
+    size: CitySize.MEDIUM,
   },
   6: {
     cityId: 6,
@@ -62,6 +90,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.5665, lng: 126.978 },
     zoom: 12,
     searchKeyword: 'Seoul, South Korea',
+    size: CitySize.LARGE,
   },
   8: {
     cityId: 8,
@@ -70,6 +99,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 35.8562, lng: 129.2247 },
     zoom: 13,
     searchKeyword: 'Gyeongju, South Korea',
+    size: CitySize.SMALL,
   },
   10: {
     cityId: 10,
@@ -78,6 +108,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.7519, lng: 128.8761 },
     zoom: 13,
     searchKeyword: 'Gangneung, South Korea',
+    size: CitySize.SMALL,
   },
   13: {
     cityId: 13,
@@ -86,6 +117,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 34.7604, lng: 127.6622 },
     zoom: 13,
     searchKeyword: 'Yeosu, South Korea',
+    size: CitySize.MEDIUM,
   },
   18: {
     cityId: 18,
@@ -94,6 +126,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 34.8808, lng: 128.6214 },
     zoom: 12,
     searchKeyword: 'Geoje, South Korea',
+    size: CitySize.SMALL,
   },
   23: {
     cityId: 23,
@@ -102,6 +135,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 35.8242, lng: 127.148 },
     zoom: 13,
     searchKeyword: 'Jeonju, South Korea',
+    size: CitySize.SMALL,
   },
   24: {
     cityId: 24,
@@ -110,6 +144,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 35.4164, lng: 127.3903 },
     zoom: 13,
     searchKeyword: 'Namwon, South Korea',
+    size: CitySize.SMALL,
   },
   29: {
     cityId: 29,
@@ -118,6 +153,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 36.019, lng: 129.3435 },
     zoom: 12,
     searchKeyword: 'Pohang, South Korea',
+    size: CitySize.MEDIUM,
   },
   30: {
     cityId: 30,
@@ -126,6 +162,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 36.3504, lng: 127.3845 },
     zoom: 12,
     searchKeyword: 'Daejeon, South Korea',
+    size: CitySize.MEDIUM,
   },
   34: {
     cityId: 34,
@@ -134,6 +171,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.4563, lng: 126.7052 },
     zoom: 12,
     searchKeyword: 'Incheon, South Korea',
+    size: CitySize.MEDIUM,
   },
   35: {
     cityId: 35,
@@ -142,6 +180,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.8813, lng: 127.7298 },
     zoom: 13,
     searchKeyword: 'Chuncheon, South Korea',
+    size: CitySize.SMALL,
   },
   40: {
     cityId: 40,
@@ -150,6 +189,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 35.9676, lng: 126.7372 },
     zoom: 13,
     searchKeyword: 'Gunsan, South Korea',
+    size: CitySize.MEDIUM,
   },
   42: {
     cityId: 42,
@@ -158,6 +198,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 34.8118, lng: 126.3922 },
     zoom: 13,
     searchKeyword: 'Mokpo, South Korea',
+    size: CitySize.MEDIUM,
   },
   49: {
     cityId: 49,
@@ -166,6 +207,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 36.5684, lng: 128.7294 },
     zoom: 13,
     searchKeyword: 'Andong, South Korea',
+    size: CitySize.SMALL,
   },
   52: {
     cityId: 52,
@@ -174,6 +216,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.4844, lng: 130.9057 },
     zoom: 12,
     searchKeyword: 'Ulleungdo, South Korea',
+    size: CitySize.SMALL,
   },
   56: {
     cityId: 56,
@@ -182,6 +225,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.8316, lng: 127.5109 },
     zoom: 13,
     searchKeyword: 'Gapyeong, South Korea',
+    size: CitySize.SMALL,
   },
   59: {
     cityId: 59,
@@ -190,6 +234,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.1326, lng: 128.1911 },
     zoom: 13,
     searchKeyword: 'Jecheon, South Korea',
+    size: CitySize.SMALL,
   },
   60: {
     cityId: 60,
@@ -198,6 +243,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.2636, lng: 127.0286 },
     zoom: 13,
     searchKeyword: 'Suwon, South Korea',
+    size: CitySize.MEDIUM,
   },
   78: {
     cityId: 78,
@@ -206,6 +252,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.1836, lng: 128.4617 },
     zoom: 13,
     searchKeyword: 'Yeongwol, South Korea',
+    size: CitySize.SMALL,
   },
 
   // 유럽
@@ -216,6 +263,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 48.8566, lng: 2.3522 },
     zoom: 12,
     searchKeyword: 'Paris, France',
+    size: CitySize.MEDIUM,
   },
   9: {
     cityId: 9,
@@ -224,6 +272,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 51.5074, lng: -0.1278 },
     zoom: 12,
     searchKeyword: 'London, United Kingdom',
+    size: CitySize.EXTRA_LARGE,
   },
   17: {
     cityId: 17,
@@ -232,6 +281,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 41.3851, lng: 2.1734 },
     zoom: 12,
     searchKeyword: 'Barcelona, Spain',
+    size: CitySize.MEDIUM,
   },
   19: {
     cityId: 19,
@@ -240,6 +290,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 41.9028, lng: 12.4964 },
     zoom: 12,
     searchKeyword: 'Rome, Italy',
+    size: CitySize.MEDIUM,
   },
   28: {
     cityId: 28,
@@ -248,6 +299,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 50.0755, lng: 14.4378 },
     zoom: 12,
     searchKeyword: 'Prague, Czech Republic',
+    size: CitySize.MEDIUM,
   },
   31: {
     cityId: 31,
@@ -256,6 +308,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 40.4168, lng: -3.7038 },
     zoom: 12,
     searchKeyword: 'Madrid, Spain',
+    size: CitySize.MEDIUM,
   },
   32: {
     cityId: 32,
@@ -264,6 +317,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 48.2082, lng: 16.3738 },
     zoom: 12,
     searchKeyword: 'Vienna, Austria',
+    size: CitySize.MEDIUM,
   },
   33: {
     cityId: 33,
@@ -272,6 +326,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 43.7696, lng: 11.2558 },
     zoom: 13,
     searchKeyword: 'Florence, Italy',
+    size: CitySize.MEDIUM,
   },
   39: {
     cityId: 39,
@@ -280,6 +335,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 46.6863, lng: 7.8632 },
     zoom: 13,
     searchKeyword: 'Interlaken, Switzerland',
+    size: CitySize.MEDIUM,
   },
   41: {
     cityId: 41,
@@ -288,6 +344,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 47.4979, lng: 19.0402 },
     zoom: 12,
     searchKeyword: 'Budapest, Hungary',
+    size: CitySize.MEDIUM,
   },
   44: {
     cityId: 44,
@@ -296,6 +353,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 45.4408, lng: 12.3155 },
     zoom: 13,
     searchKeyword: 'Venice, Italy',
+    size: CitySize.MEDIUM,
   },
   45: {
     cityId: 45,
@@ -304,6 +362,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 45.4642, lng: 9.19 },
     zoom: 12,
     searchKeyword: 'Milan, Italy',
+    size: CitySize.MEDIUM,
   },
   47: {
     cityId: 47,
@@ -312,6 +371,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 52.52, lng: 13.405 },
     zoom: 12,
     searchKeyword: 'Berlin, Germany',
+    size: CitySize.MEDIUM,
   },
   51: {
     cityId: 51,
@@ -320,6 +380,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 50.1109, lng: 8.6821 },
     zoom: 12,
     searchKeyword: 'Frankfurt, Germany',
+    size: CitySize.MEDIUM,
   },
   53: {
     cityId: 53,
@@ -328,6 +389,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 48.1351, lng: 11.582 },
     zoom: 12,
     searchKeyword: 'Munich, Germany',
+    size: CitySize.MEDIUM,
   },
   54: {
     cityId: 54,
@@ -336,6 +398,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 52.3676, lng: 4.9041 },
     zoom: 12,
     searchKeyword: 'Amsterdam, Netherlands',
+    size: CitySize.MEDIUM,
   },
   55: {
     cityId: 55,
@@ -344,6 +407,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 41.0082, lng: 28.9784 },
     zoom: 11,
     searchKeyword: 'Istanbul, Turkey',
+    size: CitySize.MEDIUM,
   },
   58: {
     cityId: 58,
@@ -352,6 +416,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 47.8095, lng: 13.055 },
     zoom: 13,
     searchKeyword: 'Salzburg, Austria',
+    size: CitySize.MEDIUM,
   },
   63: {
     cityId: 63,
@@ -360,6 +425,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 38.7223, lng: -9.1393 },
     zoom: 12,
     searchKeyword: 'Lisbon, Portugal',
+    size: CitySize.MEDIUM,
   },
   64: {
     cityId: 64,
@@ -368,6 +434,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 47.3769, lng: 8.5417 },
     zoom: 12,
     searchKeyword: 'Zurich, Switzerland',
+    size: CitySize.MEDIUM,
   },
   66: {
     cityId: 66,
@@ -376,6 +443,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 50.8503, lng: 4.3517 },
     zoom: 12,
     searchKeyword: 'Brussels, Belgium',
+    size: CitySize.MEDIUM,
   },
   70: {
     cityId: 70,
@@ -384,6 +452,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 43.7102, lng: 7.262 },
     zoom: 12,
     searchKeyword: 'Nice, France',
+    size: CitySize.MEDIUM,
   },
   71: {
     cityId: 71,
@@ -392,6 +461,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 55.6761, lng: 12.5683 },
     zoom: 12,
     searchKeyword: 'Copenhagen, Denmark',
+    size: CitySize.MEDIUM,
   },
   73: {
     cityId: 73,
@@ -400,6 +470,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 46.948, lng: 7.4474 },
     zoom: 13,
     searchKeyword: 'Bern, Switzerland',
+    size: CitySize.MEDIUM,
   },
   74: {
     cityId: 74,
@@ -408,6 +479,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 40.8518, lng: 14.2681 },
     zoom: 12,
     searchKeyword: 'Naples, Italy',
+    size: CitySize.MEDIUM,
   },
   75: {
     cityId: 75,
@@ -416,6 +488,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.9838, lng: 23.7275 },
     zoom: 12,
     searchKeyword: 'Athens, Greece',
+    size: CitySize.MEDIUM,
   },
   77: {
     cityId: 77,
@@ -424,6 +497,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 55.7558, lng: 37.6173 },
     zoom: 11,
     searchKeyword: 'Moscow, Russia',
+    size: CitySize.MEDIUM,
   },
   81: {
     cityId: 81,
@@ -432,6 +506,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 50.9375, lng: 6.9603 },
     zoom: 12,
     searchKeyword: 'Cologne, Germany',
+    size: CitySize.MEDIUM,
   },
   82: {
     cityId: 82,
@@ -440,6 +515,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 46.2044, lng: 6.1432 },
     zoom: 12,
     searchKeyword: 'Geneva, Switzerland',
+    size: CitySize.MEDIUM,
   },
   83: {
     cityId: 83,
@@ -448,6 +524,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 59.9139, lng: 10.7522 },
     zoom: 12,
     searchKeyword: 'Oslo, Norway',
+    size: CitySize.MEDIUM,
   },
   84: {
     cityId: 84,
@@ -456,6 +533,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 60.1699, lng: 24.9384 },
     zoom: 12,
     searchKeyword: 'Helsinki, Finland',
+    size: CitySize.MEDIUM,
   },
   85: {
     cityId: 85,
@@ -464,6 +542,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 53.5511, lng: 9.9937 },
     zoom: 12,
     searchKeyword: 'Hamburg, Germany',
+    size: CitySize.MEDIUM,
   },
   86: {
     cityId: 86,
@@ -472,6 +551,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 59.9311, lng: 30.3609 },
     zoom: 11,
     searchKeyword: 'Saint Petersburg, Russia',
+    size: CitySize.MEDIUM,
   },
   88: {
     cityId: 88,
@@ -480,6 +560,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 45.815, lng: 15.9819 },
     zoom: 12,
     searchKeyword: 'Zagreb, Croatia',
+    size: CitySize.MEDIUM,
   },
   90: {
     cityId: 90,
@@ -488,6 +569,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 47.5596, lng: 7.5886 },
     zoom: 13,
     searchKeyword: 'Basel, Switzerland',
+    size: CitySize.MEDIUM,
   },
   94: {
     cityId: 94,
@@ -496,6 +578,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 51.2194, lng: 4.4025 },
     zoom: 12,
     searchKeyword: 'Antwerp, Belgium',
+    size: CitySize.MEDIUM,
   },
 
   // 동남아시아
@@ -506,6 +589,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 13.7563, lng: 100.5018 },
     zoom: 12,
     searchKeyword: 'Bangkok, Thailand',
+    size: CitySize.MEDIUM,
   },
   14: {
     cityId: 14,
@@ -514,6 +598,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 25.033, lng: 121.5654 },
     zoom: 12,
     searchKeyword: 'Taipei, Taiwan',
+    size: CitySize.MEDIUM,
   },
   15: {
     cityId: 15,
@@ -522,6 +607,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 1.3521, lng: 103.8198 },
     zoom: 12,
     searchKeyword: 'Singapore',
+    size: CitySize.MEDIUM,
   },
   16: {
     cityId: 16,
@@ -530,6 +616,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 16.0544, lng: 108.2022 },
     zoom: 12,
     searchKeyword: 'Da Nang, Vietnam',
+    size: CitySize.MEDIUM,
   },
   21: {
     cityId: 21,
@@ -538,6 +625,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 22.3193, lng: 114.1694 },
     zoom: 11,
     searchKeyword: 'Hong Kong',
+    size: CitySize.MEDIUM,
   },
   26: {
     cityId: 26,
@@ -546,6 +634,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 12.2388, lng: 109.1967 },
     zoom: 12,
     searchKeyword: 'Nha Trang, Vietnam',
+    size: CitySize.MEDIUM,
   },
   37: {
     cityId: 37,
@@ -554,6 +643,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 31.2304, lng: 121.4737 },
     zoom: 11,
     searchKeyword: 'Shanghai, China',
+    size: CitySize.MEDIUM,
   },
   38: {
     cityId: 38,
@@ -562,6 +652,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: -8.4095, lng: 115.1889 },
     zoom: 11,
     searchKeyword: 'Bali, Indonesia',
+    size: CitySize.MEDIUM,
   },
   43: {
     cityId: 43,
@@ -570,6 +661,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 10.8231, lng: 106.6297 },
     zoom: 12,
     searchKeyword: 'Ho Chi Minh City, Vietnam',
+    size: CitySize.MEDIUM,
   },
   46: {
     cityId: 46,
@@ -578,6 +670,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 21.0285, lng: 105.8542 },
     zoom: 12,
     searchKeyword: 'Hanoi, Vietnam',
+    size: CitySize.MEDIUM,
   },
   62: {
     cityId: 62,
@@ -586,6 +679,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 18.7883, lng: 98.9853 },
     zoom: 12,
     searchKeyword: 'Chiang Mai, Thailand',
+    size: CitySize.MEDIUM,
   },
   65: {
     cityId: 65,
@@ -594,6 +688,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 39.9042, lng: 116.4074 },
     zoom: 11,
     searchKeyword: 'Beijing, China',
+    size: CitySize.MEDIUM,
   },
   68: {
     cityId: 68,
@@ -602,6 +697,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 22.6273, lng: 120.3014 },
     zoom: 12,
     searchKeyword: 'Kaohsiung, Taiwan',
+    size: CitySize.MEDIUM,
   },
   69: {
     cityId: 69,
@@ -610,6 +706,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 3.139, lng: 101.6869 },
     zoom: 12,
     searchKeyword: 'Kuala Lumpur, Malaysia',
+    size: CitySize.MEDIUM,
   },
   72: {
     cityId: 72,
@@ -618,6 +715,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 14.5995, lng: 120.9842 },
     zoom: 12,
     searchKeyword: 'Manila, Philippines',
+    size: CitySize.MEDIUM,
   },
   79: {
     cityId: 79,
@@ -626,6 +724,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 24.1477, lng: 120.6736 },
     zoom: 12,
     searchKeyword: 'Taichung, Taiwan',
+    size: CitySize.MEDIUM,
   },
   80: {
     cityId: 80,
@@ -634,6 +733,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 43.1056, lng: 131.8735 },
     zoom: 12,
     searchKeyword: 'Vladivostok, Russia',
+    size: CitySize.MEDIUM,
   },
   87: {
     cityId: 87,
@@ -642,6 +742,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 9.538, lng: 100.014 },
     zoom: 12,
     searchKeyword: 'Koh Samui, Thailand',
+    size: CitySize.MEDIUM,
   },
   89: {
     cityId: 89,
@@ -650,6 +751,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 22.9999, lng: 120.2269 },
     zoom: 12,
     searchKeyword: 'Tainan, Taiwan',
+    size: CitySize.MEDIUM,
   },
   91: {
     cityId: 91,
@@ -658,6 +760,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 11.5564, lng: 104.9282 },
     zoom: 12,
     searchKeyword: 'Phnom Penh, Cambodia',
+    size: CitySize.MEDIUM,
   },
   92: {
     cityId: 92,
@@ -666,6 +769,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 41.2995, lng: 69.2401 },
     zoom: 12,
     searchKeyword: 'Tashkent, Uzbekistan',
+    size: CitySize.MEDIUM,
   },
   93: {
     cityId: 93,
@@ -674,6 +778,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 17.9757, lng: 102.6331 },
     zoom: 12,
     searchKeyword: 'Vientiane, Laos',
+    size: CitySize.MEDIUM,
   },
   95: {
     cityId: 95,
@@ -682,6 +787,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 32.0853, lng: 34.7818 },
     zoom: 12,
     searchKeyword: 'Tel Aviv, Israel',
+    size: CitySize.MEDIUM,
   },
   96: {
     cityId: 96,
@@ -690,6 +796,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 21.9588, lng: 96.0891 },
     zoom: 12,
     searchKeyword: 'Mandalay, Myanmar',
+    size: CitySize.MEDIUM,
   },
 
   // 북미/오세아니아
@@ -700,6 +807,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 40.7128, lng: -74.006 },
     zoom: 12,
     searchKeyword: 'New York City, USA',
+    size: CitySize.EXTRA_LARGE,
   },
   20: {
     cityId: 20,
@@ -708,6 +816,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 21.3099, lng: -157.8581 },
     zoom: 11,
     searchKeyword: 'Honolulu, Hawaii, USA',
+    size: CitySize.EXTRA_LARGE,
   },
   22: {
     cityId: 22,
@@ -716,6 +825,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: -33.8688, lng: 151.2093 },
     zoom: 12,
     searchKeyword: 'Sydney, Australia',
+    size: CitySize.MEDIUM,
   },
   25: {
     cityId: 25,
@@ -724,6 +834,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 13.4443, lng: 144.7937 },
     zoom: 11,
     searchKeyword: 'Guam',
+    size: CitySize.MEDIUM,
   },
   27: {
     cityId: 27,
@@ -732,6 +843,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 34.0522, lng: -118.2437 },
     zoom: 11,
     searchKeyword: 'Los Angeles, USA',
+    size: CitySize.EXTRA_LARGE,
   },
   36: {
     cityId: 36,
@@ -740,6 +852,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 37.7749, lng: -122.4194 },
     zoom: 12,
     searchKeyword: 'San Francisco, USA',
+    size: CitySize.MEDIUM,
   },
   48: {
     cityId: 48,
@@ -748,6 +861,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 49.2827, lng: -123.1207 },
     zoom: 12,
     searchKeyword: 'Vancouver, Canada',
+    size: CitySize.MEDIUM,
   },
   50: {
     cityId: 50,
@@ -756,6 +870,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: -37.8136, lng: 144.9631 },
     zoom: 12,
     searchKeyword: 'Melbourne, Australia',
+    size: CitySize.MEDIUM,
   },
   57: {
     cityId: 57,
@@ -764,6 +879,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 43.6532, lng: -79.3832 },
     zoom: 12,
     searchKeyword: 'Toronto, Canada',
+    size: CitySize.MEDIUM,
   },
   61: {
     cityId: 61,
@@ -772,6 +888,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 15.2, lng: 145.75 },
     zoom: 12,
     searchKeyword: 'Saipan, Northern Mariana Islands',
+    size: CitySize.MEDIUM,
   },
   67: {
     cityId: 67,
@@ -780,6 +897,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: -27.4698, lng: 153.0251 },
     zoom: 12,
     searchKeyword: 'Brisbane, Australia',
+    size: CitySize.MEDIUM,
   },
   76: {
     cityId: 76,
@@ -788,6 +906,7 @@ export const cityMapConfigs: Record<number, CityMapConfig> = {
     center: { lat: 45.5017, lng: -73.5673 },
     zoom: 12,
     searchKeyword: 'Montreal, Canada',
+    size: CitySize.MEDIUM,
   },
 };
 
@@ -804,6 +923,7 @@ export const defaultMapConfig: CityMapConfig = {
   center: { lat: 37.5665, lng: 126.978 },
   zoom: 12,
   searchKeyword: 'Seoul, South Korea',
+  size: CitySize.LARGE,
 };
 
 // 도시 이름으로 설정 찾기 (백업용)

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { getCityMapConfig, defaultMapConfig, calculateDynamicZoom } from './cityMapConfig';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -46,15 +46,15 @@ const router = createRouter({
           component: () => import('@/views/MyPage.vue'),
           meta: { requiresAuth: true },
         },
+        {
+          path: '/plan/:id',
+          name: 'plan-detail',
+          component: () => import('@/views/PlanDetail.vue'),
+          props: true,
+        },
       ],
     },
 
-    {
-      path: '/plan/:id',
-      name: 'plan-detail',
-      component: () => import('@/views/PlanDetail.vue'),
-      props: true,
-    },
     {
       path: '/plan',
       name: 'plan',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -50,7 +50,7 @@ const router = createRouter({
     },
 
     {
-      path: '/plans/:id',
+      path: '/plan/:id',
       name: 'plan-detail',
       component: () => import('@/views/PlanDetail.vue'),
       props: true,

--- a/src/views/PlanDetail.vue
+++ b/src/views/PlanDetail.vue
@@ -1,10 +1,537 @@
 <script setup lang="ts">
+import { ref, onMounted, computed, watch } from 'vue';
+import { api } from '@/services/api';
+import type { ApiResponse } from '@/services/api/types';
+import { AxiosError } from 'axios';
+import { usePlanMap } from '@/composables/plan';
+import { getCityMapConfig, defaultMapConfig, calculateDynamicZoom } from '@/constants';
+import { Badge } from '@/components/ui/badge';
+
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { CalendarDays, MapPin, Users } from 'lucide-vue-next';
+import { dayColors } from '@/composables/plan/usePlanMap';
+
 const props = defineProps<{ id: string }>();
-console.log(props.id);
+
+interface Participant {
+  userId: number;
+  nickname: string;
+}
+
+interface Plan {
+  planId: number;
+  placeId: string;
+  placeName: string;
+  latitude: number;
+  longitude: number;
+  day: number;
+  planOrder: number;
+  placeTypeId: number;
+  memo: string | null;
+}
+
+interface TripDetail {
+  tripId: number;
+  cityId: number;
+  title: string;
+  createAt: string;
+  startDate: string;
+  endDate: string;
+  plans: Plan[];
+  participants: Participant[];
+}
+
+const tripDetail = ref<TripDetail | null>(null);
+const loading = ref(false);
+const error = ref<string>('');
+
+// 지도 관련 - 포커싱 옵션 추가
+const { initMap, addMarkerForDay, moveToLocation } = usePlanMap();
+
+// 현재 도시의 지도 설정 가져오기
+const currentCityConfig = computed(() => {
+  if (!tripDetail.value) return defaultMapConfig;
+
+  const config = getCityMapConfig(tripDetail.value.cityId);
+  if (config) {
+    return config;
+  }
+
+  // cityId에 해당하는 설정이 없으면 기본 설정 반환
+  return defaultMapConfig;
+});
+
+// 계산된 속성들
+const totalDays = computed(() => {
+  if (!tripDetail.value) return 0;
+  const start = new Date(tripDetail.value.startDate);
+  const end = new Date(tripDetail.value.endDate);
+  return Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+});
+
+const plansByDay = computed(() => {
+  if (!tripDetail.value?.plans) return {};
+
+  const grouped: Record<number, Plan[]> = {};
+
+  tripDetail.value.plans.forEach(plan => {
+    if (!grouped[plan.day]) {
+      grouped[plan.day] = [];
+    }
+    grouped[plan.day].push(plan);
+  });
+
+  // 각 일자별로 planOrder 순서대로 정렬
+  Object.keys(grouped).forEach(day => {
+    grouped[Number(day)] = grouped[Number(day)].sort((a, b) => a.planOrder - b.planOrder);
+  });
+
+  return grouped;
+});
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  });
+};
+
+const getDateForDay = (day: number) => {
+  if (!tripDetail.value) return '';
+
+  const startDate = new Date(tripDetail.value.startDate);
+  const targetDate = new Date(startDate);
+  targetDate.setDate(startDate.getDate() + day - 1);
+
+  return targetDate.toLocaleDateString('ko-KR', {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+  });
+};
+
+const getPlaceTypeText = (placeTypeId: number) => {
+  const typeMap: Record<number, string> = {
+    1: '숙박시설',
+    2: '관광지',
+    3: '음식점',
+    4: '카페',
+    5: '쇼핑',
+    6: '기타',
+  };
+  return typeMap[placeTypeId] || '기타';
+};
+
+const getPlaceTypeColor = (placeTypeId: number) => {
+  const colorMap: Record<number, string> = {
+    1: 'bg-blue-100 text-blue-800',
+    2: 'bg-green-100 text-green-800',
+    3: 'bg-orange-100 text-orange-800',
+    4: 'bg-purple-100 text-purple-800',
+    5: 'bg-pink-100 text-pink-800',
+    6: 'bg-gray-100 text-gray-800',
+  };
+  return colorMap[placeTypeId] || 'bg-gray-100 text-gray-800';
+};
+
+const getDayColor = (day: number) => {
+  return dayColors[day - 1] || '#888';
+};
+
+// 장소 클릭 시 지도 중심 이동하는 함수
+const focusOnPlace = (plan: Plan) => {
+  const location = new google.maps.LatLng(plan.latitude, plan.longitude);
+  moveToLocation(location);
+};
+
+// 여행 계획 조회 함수
+const fetchTripDetail = async () => {
+  loading.value = true;
+  error.value = '';
+
+  try {
+    const response = await api.get<ApiResponse<TripDetail>>(`/api/trips/${props.id}/plan`);
+
+    if (response.status === 200 && response.data.statusCode === 200) {
+      if ('data' in response.data) {
+        tripDetail.value = response.data.data;
+        console.log('여행 계획 데이터:', tripDetail.value);
+      }
+    } else {
+      error.value = response.data.message || '데이터를 불러올 수 없습니다.';
+    }
+  } catch (err) {
+    console.error('API 호출 실패:', err);
+
+    if (err instanceof AxiosError && err.response?.data?.message) {
+      error.value = err.response.data.message;
+    } else if (err instanceof AxiosError && err.response?.status === 401) {
+      error.value = '로그인이 필요합니다.';
+    } else if (err instanceof AxiosError && err.response?.status === 400) {
+      error.value = '잘못된 요청입니다.';
+    } else {
+      error.value = '네트워크 오류가 발생했습니다.';
+    }
+  } finally {
+    loading.value = false;
+  }
+};
+
+// 지도를 특정 도시로 초기화하는 함수 (PlanView.vue 참고)
+const initializeMapForCity = async () => {
+  try {
+    const map = await initMap();
+    if (!map) return;
+
+    // 1. 미리 설정된 좌표가 있으면 바로 이동
+    if (currentCityConfig.value.center) {
+      const location = new google.maps.LatLng(
+        currentCityConfig.value.center.lat,
+        currentCityConfig.value.center.lng
+      );
+      moveToLocation(location);
+      map.setZoom(calculateDynamicZoom(currentCityConfig.value));
+    }
+
+    // 2. 미리 설정된 좌표가 없으면 지오코딩으로 검색
+    await geocodeAndMoveToCity(map);
+  } catch (error) {
+    console.error('지도 초기화 오류:', error);
+  }
+};
+
+// 지오코딩을 통해 도시 위치 검색하고 이동하는 함수 (PlanView.vue 참고)
+const geocodeAndMoveToCity = async (map: google.maps.Map) => {
+  try {
+    const { Geocoder } = (await google.maps.importLibrary(
+      'geocoding'
+    )) as google.maps.GeocodingLibrary;
+    const geocoder = new Geocoder();
+
+    const searchKeyword =
+      currentCityConfig.value.searchKeyword || `${currentCityConfig.value.cityEn}, South Korea`;
+
+    // 지오코드 이용
+    const response = await geocoder.geocode({
+      address: searchKeyword,
+      region: 'kr',
+    });
+
+    if (response.results.length > 0) {
+      const location = response.results[0].geometry.location;
+      moveToLocation(location);
+      map.setZoom(calculateDynamicZoom(currentCityConfig.value));
+    } else {
+      console.warn('지오코딩 결과가 없습니다. 기본 위치(서울)로 설정합니다.');
+      // 기본값으로 서울 설정
+      const defaultLocation = new google.maps.LatLng(37.5665, 126.978);
+      moveToLocation(defaultLocation);
+      map.setZoom(calculateDynamicZoom(defaultMapConfig));
+    }
+  } catch (error) {
+    console.error('지오코딩 오류:', error);
+    // 오류 발생시 기본값으로 서울 설정
+    const defaultLocation = new google.maps.LatLng(37.5665, 126.978);
+    moveToLocation(defaultLocation);
+    map.setZoom(calculateDynamicZoom(defaultMapConfig));
+  }
+};
+
+// 지도에 마커 추가하는 함수 - 수정된 버전
+const addMarkersToMap = async () => {
+  if (!tripDetail.value?.plans) return;
+
+  // 각 day별로 마커 추가
+  Object.entries(plansByDay.value).forEach(([day, plans]) => {
+    // 숙소와 일반 장소 분리
+    const accommodations = plans.filter(plan => plan.placeTypeId === 1); // 숙박시설
+    const regularPlaces = plans.filter(plan => plan.placeTypeId !== 1); // 숙박시설이 아닌 곳들
+
+    const dayPlan = {
+      accommodation:
+        accommodations.length > 0
+          ? {
+              placeId: accommodations[0].placeId,
+              name: accommodations[0].placeName,
+              location: new google.maps.LatLng(
+                accommodations[0].latitude,
+                accommodations[0].longitude
+              ),
+              address: '',
+              types: ['lodging'], // 숙소 타입 추가
+              rating: 0,
+              userRatingsTotal: 0,
+              // memo 정보를 description으로 활용
+              description: accommodations[0].memo || '편안한 숙박을 위한 최적의 장소입니다.',
+            }
+          : undefined,
+      places: regularPlaces.map(p => ({
+        placeId: p.placeId,
+        name: p.placeName,
+        location: new google.maps.LatLng(p.latitude, p.longitude),
+        address: '',
+        types: getPlaceTypesFromId(p.placeTypeId), // 타입 정보 추가
+        rating: 0,
+        userRatingsTotal: 0,
+        // memo 정보를 description으로 활용
+        description: p.memo || getDefaultDescriptionForType(p.placeTypeId),
+      })),
+    };
+
+    // 숙소 마커 추가 (있는 경우)
+    if (dayPlan.accommodation) {
+      addMarkerForDay(Number(day), dayPlan.accommodation, 'accommodation', dayPlan);
+    }
+
+    // 일반 장소 마커들을 순서대로 추가
+    regularPlaces.forEach((plan, index) => {
+      const place = {
+        placeId: plan.placeId,
+        name: plan.placeName,
+        location: new google.maps.LatLng(plan.latitude, plan.longitude),
+        address: '',
+        types: getPlaceTypesFromId(plan.placeTypeId), // 타입 정보 추가
+        rating: 0,
+        userRatingsTotal: 0,
+        // memo 정보를 description으로 활용
+        description: plan.memo || getDefaultDescriptionForType(plan.placeTypeId),
+      };
+
+      addMarkerForDay(
+        Number(day),
+        place,
+        index + 1, // 일반 장소들은 1부터 시작하는 순서 번호
+        dayPlan
+      );
+    });
+  });
+};
+
+// placeTypeId를 Google Maps types 배열로 변환하는 함수
+const getPlaceTypesFromId = (placeTypeId: number): string[] => {
+  const typeMap: Record<number, string[]> = {
+    1: ['lodging'], // 숙박시설
+    2: ['tourist_attraction'], // 관광지
+    3: ['restaurant'], // 음식점
+    4: ['cafe'], // 카페
+    5: ['shopping_mall'], // 쇼핑
+    6: ['establishment'], // 기타
+  };
+  return typeMap[placeTypeId] || ['establishment'];
+};
+
+// placeTypeId에 따른 기본 설명 생성 함수
+const getDefaultDescriptionForType = (placeTypeId: number): string => {
+  const descriptionMap: Record<number, string> = {
+    1: '편안한 숙박을 위한 최적의 장소입니다.',
+    2: '꼭 방문해보시길 추천하는 명소입니다.',
+    3: '맛있는 음식을 즐길 수 있는 곳입니다.',
+    4: '좋은 분위기에서 커피를 즐길 수 있습니다.',
+    5: '다양한 쇼핑을 즐길 수 있는 장소입니다.',
+    6: '방문할 만한 가치가 있는 장소입니다.',
+  };
+  return descriptionMap[placeTypeId] || '방문할 만한 가치가 있는 장소입니다.';
+};
+
+// 컴포넌트 마운트 시 데이터 조회
+onMounted(async () => {
+  await fetchTripDetail();
+});
+
+// tripDetail이 업데이트될 때 지도 초기화 및 마커 추가
+watch(tripDetail, async newDetail => {
+  if (newDetail) {
+    // 도시별 지도 초기화
+    await initializeMapForCity();
+
+    // 마커 추가
+    setTimeout(() => {
+      addMarkersToMap();
+    }, 500); // 지도 초기화 후 약간의 딜레이
+  }
+});
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-gray-50">
-    {{ props.id }} 계획 디테일 페이지
+  <div class="relative h-full w-screen overflow-hidden">
+    <!-- Resizable 레이아웃 -->
+    <ResizablePanelGroup direction="horizontal" class="h-full">
+      <!-- 왼쪽 패널 - 여행 정보 -->
+      <ResizablePanel :default-size="20" :min-size="20" :max-size="40">
+        <div class="relative h-full overflow-y-auto bg-white">
+          <!-- 헤더 -->
+          <div class="border-b bg-white p-6">
+            <div v-if="tripDetail" class="space-y-3">
+              <h1 class="text-2xl font-bold text-gray-900">{{ tripDetail.title }}</h1>
+
+              <!-- 여행 기간 -->
+              <div class="flex items-center gap-1 text-sm text-gray-500">
+                <CalendarDays class="h-4 w-4" />
+                <span>
+                  {{ formatDate(tripDetail.startDate) }} - {{ formatDate(tripDetail.endDate) }}
+                </span>
+                <span class="ml-2 font-medium">{{ totalDays }}일</span>
+              </div>
+
+              <!-- 여행 참가자 -->
+              <div v-if="tripDetail.participants?.length" class="flex items-center gap-2">
+                <Users class="h-4 w-4 text-gray-500" />
+                <div class="flex flex-wrap gap-1">
+                  <Badge
+                    v-for="participant in tripDetail.participants"
+                    :key="participant.userId"
+                    variant="secondary"
+                    class="bg-blue-100 text-xs text-blue-800"
+                  >
+                    {{ participant.nickname }}
+                  </Badge>
+                </div>
+                <span
+                  v-if="tripDetail.participants.length === 1"
+                  class="ml-1 text-xs text-gray-400"
+                >
+                  혼자 여행
+                </span>
+              </div>
+            </div>
+
+            <!-- 로딩 상태 -->
+            <div v-else-if="loading" class="animate-pulse">
+              <div class="mb-3 h-8 rounded bg-gray-200"></div>
+              <div class="h-4 w-3/4 rounded bg-gray-200"></div>
+            </div>
+          </div>
+
+          <!-- 콘텐츠 영역 -->
+          <div class="p-6">
+            <!-- 로딩 상태 -->
+            <div v-if="loading" class="flex items-center justify-center py-12">
+              <div class="flex flex-col items-center gap-3">
+                <div class="h-12 w-12 animate-spin rounded-full border-b-2 border-blue-600"></div>
+                <p class="text-gray-600">여행 계획을 불러오는 중...</p>
+              </div>
+            </div>
+
+            <!-- 에러 상태 -->
+            <div v-else-if="error" class="flex items-center justify-center py-12">
+              <div class="text-center">
+                <div class="mb-2 font-semibold text-red-600">오류가 발생했습니다</div>
+                <p class="text-sm text-gray-600">{{ error }}</p>
+              </div>
+            </div>
+
+            <!-- 여행 일정 -->
+            <div v-else-if="tripDetail">
+              <div class="space-y-6">
+                <div v-for="day in totalDays" :key="day">
+                  <!-- Day 헤더 -->
+                  <div class="mb-4 flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                      <div
+                        class="flex h-10 w-20 items-center justify-center rounded-lg text-lg font-bold text-white shadow-md"
+                        :style="{ backgroundColor: getDayColor(day) }"
+                      >
+                        Day {{ day }}
+                      </div>
+                      <div class="text-sm text-gray-500">
+                        {{ getDateForDay(day) }}
+                      </div>
+                    </div>
+                    <div class="text-xs text-gray-400">
+                      {{ plansByDay[day]?.length || 0 }}개 장소
+                    </div>
+                  </div>
+
+                  <!-- 장소 목록 -->
+                  <div class="rounded-lg border border-gray-200 bg-white">
+                    <div v-if="plansByDay[day]?.length" class="divide-y divide-gray-100">
+                      <div
+                        v-for="(plan, index) in plansByDay[day]"
+                        :key="plan.planId"
+                        class="group flex cursor-pointer items-center gap-3 p-4 transition-all duration-200 hover:bg-gray-50"
+                        @click="focusOnPlace(plan)"
+                      >
+                        <!-- 순서 번호 -->
+                        <div class="flex items-center">
+                          <div
+                            class="flex h-6 w-6 items-center justify-center rounded border-2 border-gray-300 bg-white text-xs font-bold text-gray-600"
+                          >
+                            {{ index + 1 }}
+                          </div>
+                        </div>
+
+                        <!-- 장소 정보 -->
+                        <div class="min-w-0 flex-1">
+                          <div class="truncate font-semibold text-gray-900">
+                            {{ plan.placeName }}
+                          </div>
+                          <div class="mt-1 flex items-center gap-2">
+                            <Badge
+                              :class="getPlaceTypeColor(plan.placeTypeId)"
+                              variant="secondary"
+                              class="text-xs"
+                            >
+                              {{ getPlaceTypeText(plan.placeTypeId) }}
+                            </Badge>
+                          </div>
+                          <div
+                            v-if="plan.memo"
+                            class="mt-2 rounded bg-gray-50 p-2 text-sm text-gray-600"
+                          >
+                            {{ plan.memo }}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- 빈 상태 -->
+                    <div
+                      v-else
+                      class="flex flex-col items-center justify-center py-8 text-gray-400"
+                    >
+                      <MapPin class="mb-2 h-8 w-8" />
+                      <div class="text-sm">선택된 장소가 없습니다</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div
+                  v-if="!Object.keys(plansByDay).length"
+                  class="flex flex-col items-center py-12 text-gray-400"
+                >
+                  <CalendarDays class="mb-3 h-12 w-12" />
+                  <div class="text-lg font-medium">여행 계획이 없습니다</div>
+                  <div class="text-sm">아직 등록된 여행 일정이 없어요</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ResizablePanel>
+
+      <!-- 리사이즈 핸들 -->
+      <ResizableHandle />
+
+      <!-- 오른쪽 패널 - 지도 영역 -->
+      <ResizablePanel :default-size="70" :min-size="50" :max-size="75">
+        <div class="relative h-full">
+          <div id="map" class="h-full w-full">
+            <!-- 지도 로딩 오버레이 -->
+            <div
+              v-if="loading"
+              class="bg-opacity-90 absolute inset-0 flex items-center justify-center bg-white"
+            >
+              <div class="flex flex-col items-center gap-3">
+                <div class="h-12 w-12 animate-spin rounded-full border-b-2 border-blue-600"></div>
+                <p class="text-gray-600">지도를 불러오는 중...</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
   </div>
 </template>

--- a/src/views/PlanDetail.vue
+++ b/src/views/PlanDetail.vue
@@ -4,5 +4,7 @@ console.log(props.id);
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-gray-50">계획 디테일 페이지</div>
+  <div class="flex min-h-screen items-center justify-center bg-gray-50">
+    {{ props.id }} 계획 디테일 페이지
+  </div>
 </template>

--- a/src/views/PlanDetail.vue
+++ b/src/views/PlanDetail.vue
@@ -198,6 +198,9 @@ const initializeMapForCity = async () => {
 
     // 2. 미리 설정된 좌표가 없으면 지오코딩으로 검색
     await geocodeAndMoveToCity(map);
+
+    // 지도 초기화가 완료된 후 마커 추가
+    await addMarkersToMap();
   } catch (error) {
     console.error('지도 초기화 오류:', error);
   }
@@ -346,11 +349,6 @@ watch(tripDetail, async newDetail => {
   if (newDetail) {
     // 도시별 지도 초기화
     await initializeMapForCity();
-
-    // 마커 추가
-    setTimeout(() => {
-      addMarkersToMap();
-    }, 500); // 지도 초기화 후 약간의 딜레이
   }
 });
 </script>

--- a/src/views/PlanList.vue
+++ b/src/views/PlanList.vue
@@ -36,7 +36,7 @@ const loadTripData = async () => {
 
 const handleNavigate = ({ tripId, isCompleted }: { tripId: number; isCompleted: boolean }) => {
   // 계획 상세 페이지로 이동 (예: /plans/123)
-  router.push(`/plans/${tripId}`);
+  router.push(`/plan/${tripId}`);
 };
 
 const goToCreateTrip = () => {


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
계획 디테일 페이지 구현

## 📌 이슈 넘버
- #25 

## 📝 작업 내용
- 계획 디테일 페이지 UI
- 도시 위치 상수로 관리
- 도시 크기에 따른 동적 zoom 구현
- 왼쪽에서 장소 클릭 시 해당 장소로 zoom 이동

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/db8f818f-9588-4278-b798-be7eb157d544)

## 💬리뷰 요구사항(선택)
- [ ] 지도 마커 클릭시 infoWindow 비활성화 -> 추후


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 여행 플랜 상세 페이지가 새롭게 추가되어, 여행 일정과 지도, 참여자 정보를 한눈에 확인할 수 있습니다.
  - 배지, 구분선, 리사이즈 가능한 패널 등 다양한 UI 컴포넌트가 도입되었습니다.
  - 여행 플랜 제출 후 성공 시 자동으로 상세 페이지로 이동하는 기능이 추가되었습니다.

- **버그 수정**
  - 여행 플랜 목록에서 상세 페이지로 이동 시 경로가 일관되게 변경되었습니다.

- **개선 사항**
  - 도시별 지도 확대/축소 레벨이 도시 규모에 따라 자동으로 조정됩니다.
  - 날짜 선택 및 확인 과정이 간소화되었습니다.

- **문서화**
  - 여러 UI 컴포넌트와 상수, 함수가 index 파일을 통해 쉽게 가져올 수 있도록 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->