### PR TITLE
[FEAT] 친구초대 api 연동

### DIFF
--- a/src/components/plan/Step2FriendInvite.vue
+++ b/src/components/plan/Step2FriendInvite.vue
@@ -1,43 +1,98 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { ref, nextTick } from 'vue';
 import { Button } from '@/components/ui/button';
 import { usePlanStore } from '@/stores/plan';
+import { checkUserByNickname } from '@/services/api';
+import { AxiosError } from 'axios';
+import { useAuthStore } from '@/stores/auth';
 
 const planStore = usePlanStore();
+const authStore = useAuthStore();
 const nicknameError = ref('');
 const showError = ref(false);
+const isCheckingUser = ref(false);
+const nicknameInput = ref<HTMLInputElement | null>(null);
 
-// 닉네임 유효성 검사
+// 닉네임 유효성 검사 (기본 검사만)
 const validateNickname = (nickname: string) => {
   if (!nickname.trim()) return '닉네임을 입력해주세요.';
   if (nickname.length < 2) return '닉네임은 2글자 이상이어야 합니다.';
   if (nickname.length > 20) return '닉네임은 20글자 이하여야 합니다.';
-  if (planStore.invitedFriends.includes(nickname)) return '이미 초대된 친구입니다.';
+  if (nickname === authStore.user?.nickname) return '본인은 초대할 수 없습니다.';
+  if (planStore.invitedFriends.some(friend => friend.nickname === nickname)) {
+    return '이미 초대된 친구입니다.';
+  }
   return '';
 };
 
-// 닉네임 유효성 체크
-const isValidNickname = computed(() => {
-  const nickname = planStore.inviteNickname?.trim() || '';
-  return validateNickname(nickname) === '';
-});
-
-const addFriend = () => {
+const addFriend = async () => {
   const nickname = planStore.inviteNickname?.trim() || '';
   const error = validateNickname(nickname);
 
   if (error) {
     nicknameError.value = error;
     showError.value = true;
+    await nextTick();
+    nicknameInput.value?.focus();
     return;
   }
 
-  nicknameError.value = '';
-  planStore.addFriend(nickname);
-  planStore.inviteNickname = '';
-  // 입력 필드를 비운 후 에러 상태도 초기화
-  nicknameError.value = '';
-  showError.value = false;
+  // API 호출로 사용자 존재 확인
+  try {
+    isCheckingUser.value = true;
+    nicknameError.value = '';
+    showError.value = false;
+
+    const response = await checkUserByNickname(nickname);
+
+    if (response.statusCode === 200 && 'data' in response) {
+      if (response.data.exists && response.data.userId) {
+        // 사용자가 존재하는 경우 - 친구 목록에 추가
+        const newFriend = {
+          userId: response.data.userId,
+          nickname: response.data.nickname || nickname,
+        };
+
+        planStore.addFriendWithId(newFriend);
+        planStore.inviteNickname = '';
+        showError.value = false;
+      } else {
+        // 사용자가 존재하지 않는 경우
+        nicknameError.value = '존재하지 않는 사용자입니다.';
+        showError.value = true;
+      }
+    } else {
+      nicknameError.value = response.message || '사용자 확인 중 오류가 발생했습니다.';
+      showError.value = true;
+    }
+  } catch (error) {
+    console.error('사용자 확인 API 오류:', error);
+
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 400) {
+        nicknameError.value = error.response.data?.message || '잘못된 요청입니다.';
+      } else if (error.response && error.response.status >= 500) {
+        nicknameError.value = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+      } else {
+        nicknameError.value = '네트워크 오류가 발생했습니다.';
+      }
+    } else {
+      nicknameError.value = '예상치 못한 오류가 발생했습니다.';
+    }
+
+    showError.value = true;
+  } finally {
+    isCheckingUser.value = false;
+    if (showError.value) {
+      await nextTick();
+      nicknameInput.value?.focus();
+    }
+  }
+};
+
+// 친구 삭제
+const removeFriend = (userId: number) => {
+  planStore.removeFriendById(userId);
 };
 
 // 친구 초대 건너뛰기
@@ -45,6 +100,16 @@ const skipFriendInvite = () => {
   // 혼자 여행하기 선택 시 다음 단계로
   planStore.nextStep();
 };
+
+// planStore에 초대된 친구들의 userId 배열을 제공하는 함수
+const getInvitedFriendIds = (): number[] => {
+  return planStore.invitedFriends.map(friend => friend.userId).filter(id => id > 0);
+};
+
+// 부모 컴포넌트에서 사용할 수 있도록 노출
+defineExpose({
+  getInvitedFriendIds,
+});
 </script>
 
 <template>
@@ -57,14 +122,27 @@ const skipFriendInvite = () => {
       <label class="mb-2 block text-sm font-medium">친구 닉네임</label>
       <div class="flex gap-2">
         <input
+          ref="nicknameInput"
           v-model="planStore.inviteNickname"
           type="text"
           placeholder="친구의 닉네임을 입력하세요"
           class="focus:border-bold focus:ring-bold flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-1 focus:outline-none"
-          @keyup.enter="isValidNickname && addFriend()"
-          @input="showError = true"
+          :disabled="isCheckingUser"
+          @keyup.enter="addFriend"
+          @input="
+            () => {
+              showError = false;
+              nicknameError = '';
+            }
+          "
         />
-        <Button :disabled="!isValidNickname" @click="addFriend">초대하기</Button>
+        <Button @click="addFriend" class="hover:bg-secondary bg-primary">
+          <span v-if="isCheckingUser" class="flex items-center gap-2">
+            <div class="h-4 w-4 animate-spin rounded-full border-b-2 border-white"></div>
+            확인중...
+          </span>
+          <span v-else>초대하기</span>
+        </Button>
       </div>
       <p v-if="showError && nicknameError" class="mt-1 text-sm text-red-500">{{ nicknameError }}</p>
     </div>
@@ -74,23 +152,26 @@ const skipFriendInvite = () => {
       <h3 class="mb-3 font-semibold">초대된 친구들 ({{ planStore.invitedFriends.length }}명)</h3>
       <div class="space-y-2">
         <div
-          v-for="(friend, index) in planStore.invitedFriends"
-          :key="index"
+          v-for="friend in planStore.invitedFriends"
+          :key="friend.userId"
           class="flex items-center justify-between rounded-lg border bg-gray-50 p-3"
         >
           <div class="flex items-center gap-2">
             <div
               class="bg-secondary flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium text-gray-800"
             >
-              {{ friend.charAt(0).toUpperCase() }}
+              {{ friend.nickname.charAt(0).toUpperCase() }}
             </div>
-            <span class="text-sm">{{ friend }}</span>
+            <div class="flex flex-col">
+              <span class="text-sm font-medium">{{ friend.nickname }}</span>
+              <!-- <span class="text-xs text-gray-500">ID: {{ friend.userId }}</span> -->
+            </div>
           </div>
           <Button
             variant="ghost"
             size="sm"
             class="text-red-500 hover:text-red-700"
-            @click="planStore.removeFriend(friend)"
+            @click="removeFriend(friend.userId)"
           >
             삭제
           </Button>
@@ -102,15 +183,20 @@ const skipFriendInvite = () => {
     <div class="bg-primary rounded-lg p-4">
       <h4 class="mb-2 font-medium text-gray-800">💡 알아두세요</h4>
       <ul class="space-y-1 text-sm text-gray-800">
-        <li>• 닉네임으로 친구들을 구분합니다</li>
-        <li>• 친구들도 여행 계획에 참여하여 의견을 제시할 수 있습니다</li>
+        <li>• 등록된 사용자만 초대할 수 있습니다</li>
+        <li>• 초대된 친구들도 여행 계획에 참여하여 의견을 제시할 수 있습니다</li>
         <li>• 나중에 친구를 추가하거나 제거할 수 있습니다</li>
       </ul>
     </div>
 
-    <!-- 혼자 여행하기 옵션 -->
-    <div class="mt-6">
-      <Button variant="outline" class="w-full" @click="skipFriendInvite">혼자 여행하기</Button>
+    <!-- 계속하기 및 혼자 여행하기 버튼 -->
+    <div class="mt-6 space-y-3">
+      <Button class="w-full" @click="planStore.nextStep()" :disabled="isCheckingUser">
+        다음 단계로
+      </Button>
+      <Button variant="outline" class="w-full" @click="skipFriendInvite" :disabled="isCheckingUser">
+        혼자 여행하기
+      </Button>
     </div>
   </div>
 </template>

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,3 +1,4 @@
 export { default as api } from './api';
 export type { ApiSuccess, ApiFailure, User, AuthToken } from './types';
 export { createTripPlan, updateTripPlan, type CreateTripPlanRequest } from './tripPlan';
+export { checkUserByNickname, type CheckUserResponse } from './userApi';

--- a/src/services/api/userApi.ts
+++ b/src/services/api/userApi.ts
@@ -1,0 +1,16 @@
+import api from './api';
+import type { ApiResponse } from './types';
+
+export interface CheckUserResponse {
+  exists: boolean;
+  userId: number | null;
+  nickname: string | null;
+}
+
+// 닉네임으로 사용자 존재 확인
+export const checkUserByNickname = async (
+  nickname: string
+): Promise<ApiResponse<CheckUserResponse>> => {
+  const response = await api.get(`/api/users/check?nickname=${encodeURIComponent(nickname)}`);
+  return response.data;
+};

--- a/src/views/PlanEditView.vue
+++ b/src/views/PlanEditView.vue
@@ -149,6 +149,7 @@ import Step3AccommodationDrawer from '@/components/plan/Step3AccommodationDrawer
 import Step4PlaceDrawer from '@/components/plan/Step4PlaceDrawer.vue';
 import AccommodationDaySelectModal from '@/components/plan/AccommodationDaySelectModal.vue';
 import PlaceDaySelectModal from '@/components/plan/PlaceDaySelectModal.vue';
+import { useAuthStore } from '@/stores/auth';
 import { AxiosError } from 'axios';
 
 const planStore = usePlanStore();
@@ -249,13 +250,16 @@ const loadTripData = async () => {
           end: new Date(tripDetail.endDate),
         });
 
-        // 5. dayPlans 초기화
+        // 🆕 5. 참가자(친구) 정보 설정 - 본인 제외
+        await loadExistingParticipants(tripDetail.participants);
+
+        // 6. dayPlans 초기화
         planStore.initializeDayPlans();
 
-        // 6. 기존 계획 데이터를 planStore에 설정
+        // 7. 기존 계획 데이터를 planStore에 설정
         await loadExistingPlans(tripDetail.plans);
 
-        // 7. Step 4로 이동 (편집 모드이므로)
+        // 8. Step 4로 이동 (편집 모드이므로)
         planStore.setCurrentStep(4);
 
         console.log('여행 계획 데이터 로드 완료:', tripDetail);
@@ -333,6 +337,26 @@ const loadExistingPlans = async (plans: Plan[]) => {
       }
     }
   }
+};
+
+// 🆕 기존 참가자 정보를 planStore에 로드하는 함수 추가
+const loadExistingParticipants = async (participants: Participant[]) => {
+  // 현재 로그인한 사용자 정보 가져오기 (authStore 사용)
+  const authStore = useAuthStore();
+  const currentUserId = Number(authStore.user?.userId);
+
+  // 본인을 제외한 참가자들만 초대된 친구로 설정
+  const invitedFriends = participants.filter(participant => participant.userId !== currentUserId);
+
+  // planStore에 친구 정보 설정
+  invitedFriends.forEach(participant => {
+    planStore.addFriendWithId({
+      userId: participant.userId,
+      nickname: participant.nickname,
+    });
+  });
+
+  console.log('기존 참가자 로드 완료:', invitedFriends);
 };
 
 // placeTypeId를 Google Maps types 배열로 변환하는 함수 (PlanDetail.vue와 동일)


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
친구초대 api 연동

## 📌 이슈 넘버
- #34 

## 📝 작업 내용
- 유저가 존재하면 : 리스트에 추가
- 유효성 검증(본인인지, 존재하지 않는 유저인지, 2~20글자 이내인지) 추가
- 계획 편집페이지에서 등록된 친구가 Step2에서 바로 보이도록 세팅
- 에러메세지가 뜨고나서, 입력이 감지되면 에러메세지 초기화

## 📸 스크린샷(선택)
- 친구가 추가된 모습
![image](https://github.com/user-attachments/assets/d4ad96c0-4b64-4d9a-9e41-a15a4b4394be)
- 유효성 검증에 실패한 모습
![image](https://github.com/user-attachments/assets/7918cdf7-4042-4384-892d-1f072bc9d787)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
