### PR TITLE
[FEAT] 헤더 UI 추가

### DIFF
--- a/src/components/common/CommonHeader.vue
+++ b/src/components/common/CommonHeader.vue
@@ -27,13 +27,27 @@ const handleLogout = () => {
       </div>
       <ul class="flex min-h-full items-center gap-8 text-sm">
         <li class="hover:text-bold cursor-pointer">
-          <router-link to="/" class="px-4 py-5">홈</router-link>
+          <router-link to="/" class="px-4 py-5" :class="{ 'text-bold': $route.path === '/' }" exact>
+            홈
+          </router-link>
         </li>
         <li class="hover:text-bold cursor-pointer">
-          <router-link to="/plans" class="px-4 py-5">계획 리스트</router-link>
+          <router-link
+            to="/plans"
+            class="px-4 py-5"
+            :class="{ 'text-bold': $route.path.startsWith('/plans') }"
+          >
+            계획 리스트
+          </router-link>
         </li>
         <li class="hover:text-bold cursor-pointer">
-          <router-link to="/records" class="px-4 py-5">AI 후기 리스트</router-link>
+          <router-link
+            to="/records"
+            class="px-4 py-5"
+            :class="{ 'text-bold': $route.path.startsWith('/records') }"
+          >
+            AI 후기 리스트
+          </router-link>
         </li>
       </ul>
       <div class="flex items-center">

--- a/src/components/views/home/FeaturesSection.vue
+++ b/src/components/views/home/FeaturesSection.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Card, CardContent } from '@/components/ui/card';
 import FeatureCard from './FeatureCard.vue';
 import { MapPin, Sparkles } from 'lucide-vue-next';
 import type { Component } from 'vue';
@@ -48,6 +47,7 @@ const features: Feature[] = [
           :key="index"
           :feature="feature"
           :index="index"
+          class="cursor-pointer"
         />
       </div>
     </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

헤더 UI 추가

## 📌 이슈 넘버
- #35 

## 📝 작업 내용

- 헤더 UI 추가 -> 해당 페이지일때 색상이 표시되도록 함
- 메인페이지에서 카드 컴포넌트에 cursor-pointer 적용

## 📸 스크린샷(선택)
- 메인페이지일때 헤더
![image](https://github.com/user-attachments/assets/9cb21fcb-c15a-42a8-b3c6-ffa638381d67)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 현재 경로에 따라 헤더 내비게이션 링크에 굵은 글씨 스타일이 동적으로 적용됩니다.
  - 기능 카드에 마우스 오버 시 커서가 포인터로 변경되어 카드의 클릭 가능성이 강조됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->