### PR TITLE
[FEAT] 계획 편집페이지 락 적용

### DIFF
--- a/src/composables/plan/index.ts
+++ b/src/composables/plan/index.ts
@@ -1,2 +1,3 @@
 export { usePlanMap } from './usePlanMap';
 export { usePlaceSearch } from './usePlaceSearch';
+export { useEditLock } from './useEditLock';

--- a/src/composables/plan/useEditLock.ts
+++ b/src/composables/plan/useEditLock.ts
@@ -120,13 +120,8 @@ export function useEditLock() {
           if (responseData.data.nextHeartbeat) {
             heartbeatInterval.value = responseData.data.nextHeartbeat * 1000;
           }
-        } else if (responseData.statusCode === 401) {
-          // 편집 권한 상실
-          console.warn('편집 권한을 잃었습니다');
-          await forceEndEdit();
-          alert('편집 권한이 만료되었습니다. 다시 편집을 시작해주세요.');
         }
-      } catch (error: unknown) {
+      } catch (error) {
         console.error('Heartbeat 실패:', error);
 
         // 401 에러 처리

--- a/src/composables/plan/useEditLock.ts
+++ b/src/composables/plan/useEditLock.ts
@@ -2,24 +2,7 @@ import { ref, readonly, onUnmounted } from 'vue';
 import api from '@/services/api/api';
 import type { ApiResponse, ApiSuccess } from '@/services/api/types';
 import { AxiosError } from 'axios';
-
-interface EditLockResponse {
-  success: boolean;
-  heartbeatInterval?: number;
-  currentOwner?: number;
-}
-
-interface HeartbeatResponse {
-  success: boolean;
-  nextHeartbeat?: number;
-  shouldRestart?: boolean;
-}
-
-interface EditStatusResponse {
-  locked: boolean;
-  currentOwner?: number;
-  timeRemaining?: number;
-}
+import type { EditLockResponse, HeartbeatResponse, EditStatusResponse } from '@/services/api';
 
 function isApiSuccess<T>(response: ApiResponse<T>): response is ApiSuccess<T> {
   return 'data' in response;

--- a/src/composables/plan/useEditLock.ts
+++ b/src/composables/plan/useEditLock.ts
@@ -1,0 +1,277 @@
+import { ref, readonly, onUnmounted } from 'vue';
+import api from '@/services/api/api';
+import type { ApiResponse, ApiSuccess } from '@/services/api/types';
+import { AxiosError } from 'axios';
+
+interface EditLockResponse {
+  success: boolean;
+  heartbeatInterval?: number;
+  currentOwner?: number;
+}
+
+interface HeartbeatResponse {
+  success: boolean;
+  nextHeartbeat?: number;
+  shouldRestart?: boolean;
+}
+
+interface EditStatusResponse {
+  locked: boolean;
+  currentOwner?: number;
+  timeRemaining?: number;
+}
+
+function isApiSuccess<T>(response: ApiResponse<T>): response is ApiSuccess<T> {
+  return 'data' in response;
+}
+
+export function useEditLock() {
+  const isEditing = ref(false);
+  const currentOwner = ref<number | null>(null);
+  const heartbeatTimer = ref<number | null>(null);
+  const heartbeatInterval = ref(30000); // 기본 30초
+
+  /**
+   * 편집 모드 시작 (락 획득)
+   */
+  const startEdit = async (tripId: number) => {
+    try {
+      const response = await api.post<ApiResponse<EditLockResponse>>(`/api/trips/${tripId}/lock`);
+      const responseData = response.data;
+
+      if (
+        isApiSuccess(responseData) &&
+        responseData.statusCode === 200 &&
+        responseData.data?.success
+      ) {
+        isEditing.value = true;
+        currentOwner.value = null;
+
+        // 서버에서 받은 heartbeat 간격 설정 (기본 30초)
+        if (responseData.data.heartbeatInterval) {
+          heartbeatInterval.value = responseData.data.heartbeatInterval * 1000;
+        }
+
+        // Heartbeat 시작
+        startHeartbeat(tripId);
+
+        console.log('편집 모드 시작');
+        return {
+          success: true,
+          message: '편집 모드를 시작했습니다.',
+        };
+      } else if (responseData.statusCode === 409) {
+        // 다른 사용자가 편집 중
+        if (isApiSuccess(responseData)) {
+          currentOwner.value = responseData.data?.currentOwner || null;
+        }
+        return {
+          success: false,
+          message: responseData.message || '다른 사용자가 편집 중입니다.',
+          currentOwner: currentOwner.value,
+        };
+      } else {
+        return {
+          success: false,
+          message: responseData.message || '편집 모드 시작에 실패했습니다.',
+        };
+      }
+    } catch (error: unknown) {
+      console.error('편집 모드 시작 실패:', error);
+
+      // 409 에러 처리 (서버가 409 상태코드로 응답한 경우)
+      if (error instanceof AxiosError && error.response?.status === 409) {
+        // 409 에러의 경우 응답 데이터에서 정보 추출
+        const responseData = error.response.data;
+
+        if (responseData?.data?.currentOwner) {
+          currentOwner.value = responseData.data.currentOwner;
+        } else {
+          currentOwner.value = -1; // 편집 중인 사용자가 있지만 ID를 알 수 없는 경우
+        }
+
+        console.log('409 HTTP 상태: 다른 사용자가 편집 중', {
+          currentOwner: currentOwner.value,
+          responseData: responseData,
+        });
+
+        return {
+          success: false,
+          message: responseData?.message || '다른 사용자가 편집 중입니다.',
+          currentOwner: currentOwner.value,
+        };
+      }
+
+      // 기타 에러
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : '편집 모드 시작에 실패했습니다.',
+      };
+    }
+  };
+
+  /**
+   * Heartbeat 시작
+   */
+  const startHeartbeat = (tripId: number) => {
+    // 기존 타이머가 있으면 정리
+    if (heartbeatTimer.value) {
+      clearInterval(heartbeatTimer.value);
+    }
+
+    heartbeatTimer.value = setInterval(async () => {
+      try {
+        const response = await api.post<ApiResponse<HeartbeatResponse>>(
+          `/api/trips/${tripId}/heartbeat`
+        );
+        const responseData = response.data;
+
+        if (
+          isApiSuccess(responseData) &&
+          responseData.statusCode === 200 &&
+          responseData.data?.success
+        ) {
+          console.log('Heartbeat 성공');
+
+          // 다음 heartbeat 간격 업데이트 (필요시)
+          if (responseData.data.nextHeartbeat) {
+            heartbeatInterval.value = responseData.data.nextHeartbeat * 1000;
+          }
+        } else if (responseData.statusCode === 401) {
+          // 편집 권한 상실
+          console.warn('편집 권한을 잃었습니다');
+          await forceEndEdit();
+          alert('편집 권한이 만료되었습니다. 다시 편집을 시작해주세요.');
+        }
+      } catch (error: unknown) {
+        console.error('Heartbeat 실패:', error);
+
+        // 401 에러 처리
+        if (error instanceof AxiosError && error.response?.status === 401) {
+          console.warn('편집 권한을 잃었습니다');
+          await forceEndEdit();
+          alert('편집 권한이 만료되었습니다. 다시 편집을 시작해주세요.');
+        }
+      }
+    }, heartbeatInterval.value);
+  };
+
+  /**
+   * 편집 모드 종료 (락 해제)
+   */
+  const endEdit = async (tripId: number) => {
+    // Heartbeat 중지
+    if (heartbeatTimer.value) {
+      clearInterval(heartbeatTimer.value);
+      heartbeatTimer.value = null;
+    }
+
+    // 편집 중이었다면 락 해제 API 호출
+    if (isEditing.value) {
+      try {
+        await api.delete(`/api/trips/${tripId}/lock`);
+        console.log('편집 모드 정상 종료');
+      } catch (error) {
+        console.error('락 해제 실패:', error);
+      }
+    }
+
+    // 상태 초기화
+    isEditing.value = false;
+    currentOwner.value = null;
+
+    return { success: true, message: '편집을 종료했습니다.' };
+  };
+
+  /**
+   * 강제 편집 모드 종료 (권한 상실 시)
+   */
+  const forceEndEdit = async () => {
+    // Heartbeat 중지
+    if (heartbeatTimer.value) {
+      clearInterval(heartbeatTimer.value);
+      heartbeatTimer.value = null;
+    }
+
+    // 상태만 초기화 (API 호출 없음 - 이미 권한이 없으므로)
+    isEditing.value = false;
+    currentOwner.value = null;
+
+    console.log('편집 모드 강제 종료');
+  };
+
+  /**
+   * 편집 상태 확인
+   */
+  const checkEditStatus = async (tripId: number) => {
+    try {
+      const response = await api.get<ApiResponse<EditStatusResponse>>(
+        `/api/trips/${tripId}/lock/status`
+      );
+      const responseData = response.data;
+
+      if (isApiSuccess(responseData)) {
+        const data = responseData.data;
+
+        if (data?.locked && !isEditing.value) {
+          // 다른 사용자가 편집 중
+          currentOwner.value = data.currentOwner || null;
+        } else {
+          // 편집 중인 사용자 없음
+          currentOwner.value = null;
+        }
+
+        return data;
+      }
+    } catch (error) {
+      console.error('편집 상태 확인 실패:', error);
+      return null;
+    }
+  };
+
+  /**
+   * 페이지 이탈 감지용 핸들러
+   */
+  const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    if (isEditing.value) {
+      event.preventDefault();
+      event.returnValue = '편집 중인 내용이 있습니다. 정말 나가시겠습니까?';
+      return event.returnValue;
+    }
+  };
+
+  /**
+   * 페이지 이탈 감지 시작
+   */
+  const startBeforeUnloadListener = () => {
+    window.addEventListener('beforeunload', handleBeforeUnload);
+  };
+
+  /**
+   * 페이지 이탈 감지 중지
+   */
+  const stopBeforeUnloadListener = () => {
+    window.removeEventListener('beforeunload', handleBeforeUnload);
+  };
+
+  // 컴포넌트 언마운트 시 정리
+  onUnmounted(() => {
+    if (heartbeatTimer.value) {
+      clearInterval(heartbeatTimer.value);
+    }
+    stopBeforeUnloadListener();
+  });
+
+  return {
+    // 상태 (읽기 전용)
+    isEditing: readonly(isEditing),
+    currentOwner: readonly(currentOwner),
+
+    // 메서드
+    startEdit,
+    endEdit,
+    checkEditStatus,
+    startBeforeUnloadListener,
+    stopBeforeUnloadListener,
+  };
+}

--- a/src/services/api/editLock.ts
+++ b/src/services/api/editLock.ts
@@ -1,0 +1,63 @@
+import api from './api';
+import type { ApiResponse } from './types';
+
+// 편집 락 획득 응답 타입
+export interface EditLockResponse {
+  success: boolean;
+  heartbeatInterval?: number;
+  currentOwner?: number;
+}
+
+// Heartbeat 응답 타입
+export interface HeartbeatResponse {
+  success: boolean;
+  nextHeartbeat?: number;
+  shouldRestart?: boolean;
+}
+
+// 편집 상태 응답 타입
+export interface EditStatusResponse {
+  locked: boolean;
+  currentOwner?: number;
+  timeRemaining?: number;
+}
+
+/**
+ * 편집 모드 시작 (락 획득)
+ * @param tripId 여행 ID
+ * @returns API 응답
+ */
+export const startEditMode = async (tripId: number): Promise<ApiResponse<EditLockResponse>> => {
+  const response = await api.post(`/api/trips/${tripId}/lock`);
+  return response.data;
+};
+
+/**
+ * Heartbeat 전송 (편집 중임을 알림)
+ * @param tripId 여행 ID
+ * @returns API 응답
+ */
+export const sendHeartbeat = async (tripId: number): Promise<ApiResponse<HeartbeatResponse>> => {
+  const response = await api.post(`/api/trips/${tripId}/heartbeat`);
+  return response.data;
+};
+
+/**
+ * 편집 모드 종료 (락 해제)
+ * @param tripId 여행 ID
+ * @returns API 응답
+ */
+export const endEditMode = async (tripId: number): Promise<ApiResponse<void>> => {
+  const response = await api.delete(`/api/trips/${tripId}/lock`);
+  return response.data;
+};
+
+/**
+ * 편집 상태 확인
+ * @param tripId 여행 ID
+ * @returns API 응답
+ */
+export const checkEditStatus = async (tripId: number): Promise<ApiResponse<EditStatusResponse>> => {
+  const response = await api.get(`/api/trips/${tripId}/lock/status`);
+  return response.data;
+};

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -2,3 +2,11 @@ export { default as api } from './api';
 export type { ApiSuccess, ApiFailure, User, AuthToken } from './types';
 export { createTripPlan, updateTripPlan, type CreateTripPlanRequest } from './tripPlan';
 export { checkUserByNickname, type CheckUserResponse } from './userApi';
+export {
+  sendHeartbeat,
+  endEditMode,
+  checkEditStatus,
+  type EditLockResponse,
+  type HeartbeatResponse,
+  type EditStatusResponse,
+} from './editLock';

--- a/src/services/api/tripService.ts
+++ b/src/services/api/tripService.ts
@@ -53,7 +53,7 @@ export const fetchAllTripRecords = async (): Promise<TripInfoDto[]> => {
 };
 
 // TripInfoDto -> TripStory 변환
-export const convertToTripStory = (tripInfo: TripInfoDto, index: number): TripStory => {
+export const convertToTripStory = (tripInfo: TripInfoDto): TripStory => {
   const startDate = formatDate(tripInfo.trip.startDate);
   const endDate = formatDate(tripInfo.trip.endDate);
   const periodText = `${startDate} ~ ${endDate}`;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
계획 편집페이지 락 적용

## 📌 이슈 넘버
- #41 

## 📝 작업 내용

🔒 편집 락 시스템 구현
- useEditLock Composable 개발: 편집 권한 관리, Heartbeat, 락 해제 기능
- API 연동: 락 획득/해제, Heartbeat 전송, 편집 상태 확인 API 연동
- 동시 편집 방지: 409 충돌 응답 처리 및 편집 차단 UI 구현

🎨 사용자 인터페이스 개선

- PlanEditView.vue: 편집 차단 전체화면, 편집 중 상태 표시, 재시도 기능
- PlanDetail.vue: 편집 버튼 상태 관리, 편집 중 알림 표시
- 편집 상태 시각화: 편집 가능/불가능 상태를 직관적으로 표시

⚡ 핵심 기능

- 편집 권한 획득: POST /api/trips/{tripId}/lock
- Heartbeat 전송: POST /api/trips/{tripId}/heartbeat (30초 간격)
- 편집 종료: DELETE /api/trips/{tripId}/lock
- 상태 확인: GET /api/trips/{tripId}/lock/status
- 페이지 이탈 감지: 편집 중 나갈 때 경고 및 자동 락 해제 -> 예정

🛡️ 에러 처리 및 예외 상황

- 409 충돌 처리: 다른 사용자 편집 중일 때 적절한 알림 및 차단
- 권한 상실 처리: Heartbeat 실패 시 강제 편집 모드 종료
- 네트워크 오류: 재시도 옵션 제공


## 📸 스크린샷(선택)
(왼) 사용자1 / (오) 사용자 2

왼쪽의 사용자1과 오른쪽의 사용자2는 같은 계획을 공유중.
오른쪽의 사용자2가 편집상태에 들어오면, 왼쪽의 사용자 1에서 편집을 시도했을 때 **락이 적용**되며 **동시편집으로 인한 야기되는 문제를 방지**함.

![image](https://github.com/user-attachments/assets/46191e05-f5fa-47ba-8d48-45182126f87c)


## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여행 계획 편집 시 동시 편집 방지를 위한 편집 잠금(에디트 락) 기능이 추가되었습니다.
  - 다른 사용자가 편집 중일 경우, 편집 버튼이 비활성화되고 안내 메시지가 표시됩니다.
  - 편집 화면 진입 시 잠금 상태를 확인하고, 편집 권한이 없을 경우 읽기 전용 모드 및 재시도 기능이 제공됩니다.
  - 편집 중 페이지 이탈 시 경고 알림이 표시됩니다.

- **버그 수정**
  - 편집 가능 여부 및 상태에 따라 버튼과 안내 메시지가 정확히 동작하도록 UI가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->